### PR TITLE
[#85] Main sheet use schema and allow json pointer

### DIFF
--- a/flattentool/schema.py
+++ b/flattentool/schema.py
@@ -30,8 +30,12 @@ class TitleLookup(UserDict):
     def lookup_header_list(self, title_header_list):
         first_title = title_header_list[0]
         remaining_titles = title_header_list[1:]
-        if isinstance(first_title, int):
-            return first_title + '/' + self[first_title].lookup_header_list(remaining_titles)
+        try:
+            int(first_title)
+            return first_title + '/' + self.lookup_header_list(remaining_titles)
+        except ValueError:
+            pass
+
         if first_title in self:
             if remaining_titles:
                 return self[first_title].property_name + '/' + self[first_title].lookup_header_list(remaining_titles)
@@ -51,7 +55,7 @@ class TitleLookup(UserDict):
             raise KeyError
         else:
             return self.data[key.replace(' ', '').lower()]
-    
+
     def __contains__(self, key):
         if key is None:
             return False
@@ -129,7 +133,7 @@ class SchemaParser(object):
                         yield (
                             property_name+'/'+field,
                             # TODO ambiguous use of "title"
-                            (title+':'+child_title if title and child_title else None) 
+                            (title+':'+child_title if title and child_title else None)
                         )
 
                 elif 'array' in property_type_set:

--- a/flattentool/tests/test_input_SpreadsheetInput.py
+++ b/flattentool/tests/test_input_SpreadsheetInput.py
@@ -4,13 +4,14 @@ Tests of SpreadsheetInput class from input.py, and its chidlren.
 Tests of unflatten method are in test_input_SpreadsheetInput_unflatten.py
 """
 from __future__ import unicode_literals
-from flattentool.input import SpreadsheetInput, CSVInput, XLSXInput
+from flattentool.input import SpreadsheetInput, CSVInput, XLSXInput, convert_type
 from decimal import Decimal
 from collections import OrderedDict
 import sys
 import pytest
 import openpyxl
 import datetime
+import pytz
 from six import text_type
 
 class ListInput(SpreadsheetInput):
@@ -164,73 +165,73 @@ class TestUnicodeInput(object):
 
 def test_convert_type(recwarn):
     si = SpreadsheetInput()
-    assert si.convert_type('', 'somestring') == 'somestring'
+    assert convert_type('', 'somestring') == 'somestring'
     # If not type is specified, ints are kept as ints...
-    assert si.convert_type('', 3) == 3
+    assert convert_type('', 3) == 3
 
     # ... but all other ojbects are converted to strings
     class NotAString(object):
         def __str__(self):
             return 'string representation'
     assert NotAString() != 'string representation'
-    assert si.convert_type('', NotAString()) == 'string representation'
-    assert si.convert_type('string', NotAString()) == 'string representation'
+    assert convert_type('', NotAString()) == 'string representation'
+    assert convert_type('string', NotAString()) == 'string representation'
 
-    assert si.convert_type('string', 3) == '3'
-    assert si.convert_type('number', '3') == Decimal('3')
-    assert si.convert_type('number', '1.2') == Decimal('1.2')
-    assert si.convert_type('integer', '3') == 3
-    assert si.convert_type('integer', 3) == 3
+    assert convert_type('string', 3) == '3'
+    assert convert_type('number', '3') == Decimal('3')
+    assert convert_type('number', '1.2') == Decimal('1.2')
+    assert convert_type('integer', '3') == 3
+    assert convert_type('integer', 3) == 3
 
-    assert si.convert_type('boolean', 'TRUE') is True
-    assert si.convert_type('boolean', 'True') is True
-    assert si.convert_type('boolean', 1) is True
-    assert si.convert_type('boolean', '1') is True
-    assert si.convert_type('boolean', 'FALSE') is False
-    assert si.convert_type('boolean', 'False') is False
-    assert si.convert_type('boolean', 0) is False
-    assert si.convert_type('boolean', '0') is False
-    si.convert_type('boolean', 2)
+    assert convert_type('boolean', 'TRUE') is True
+    assert convert_type('boolean', 'True') is True
+    assert convert_type('boolean', 1) is True
+    assert convert_type('boolean', '1') is True
+    assert convert_type('boolean', 'FALSE') is False
+    assert convert_type('boolean', 'False') is False
+    assert convert_type('boolean', 0) is False
+    assert convert_type('boolean', '0') is False
+    convert_type('boolean', 2)
     assert 'Unrecognised value for boolean: "2"' in text_type(recwarn.pop(UserWarning).message)
-    si.convert_type('boolean', 'test')
+    convert_type('boolean', 'test')
     assert 'Unrecognised value for boolean: "test"' in text_type(recwarn.pop(UserWarning).message)
 
-    si.convert_type('integer', 'test')
+    convert_type('integer', 'test')
     assert 'Non-integer value "test"' in text_type(recwarn.pop(UserWarning).message)
 
-    si.convert_type('number', 'test')
+    convert_type('number', 'test')
     assert 'Non-numeric value "test"' in text_type(recwarn.pop(UserWarning).message)
 
-    assert si.convert_type('string', '') is None
-    assert si.convert_type('number', '') is None
-    assert si.convert_type('integer', '') is None
-    assert si.convert_type('array', '') is None
-    assert si.convert_type('boolean', '') is None
-    assert si.convert_type('string', None) is None
-    assert si.convert_type('number', None) is None
-    assert si.convert_type('integer', None) is None
-    assert si.convert_type('array', None) is None
-    assert si.convert_type('boolean', None) is None
+    assert convert_type('string', '') is None
+    assert convert_type('number', '') is None
+    assert convert_type('integer', '') is None
+    assert convert_type('array', '') is None
+    assert convert_type('boolean', '') is None
+    assert convert_type('string', None) is None
+    assert convert_type('number', None) is None
+    assert convert_type('integer', None) is None
+    assert convert_type('array', None) is None
+    assert convert_type('boolean', None) is None
 
-    assert si.convert_type('array', 'one') == ['one']
-    assert si.convert_type('array', 'one;two') == ['one', 'two']
-    assert si.convert_type('array', 'one,two;three,four') == [['one', 'two'], ['three', 'four']]
+    assert convert_type('array', 'one') == ['one']
+    assert convert_type('array', 'one;two') == ['one', 'two']
+    assert convert_type('array', 'one,two;three,four') == [['one', 'two'], ['three', 'four']]
 
     with pytest.raises(ValueError) as e:
-        si.convert_type('notatype', 'test')
+        convert_type('notatype', 'test')
     assert 'Unrecognised type: "notatype"' in text_type(e)
 
-    assert si.convert_type('string', datetime.datetime(2015, 1, 1)) == '2015-01-01T00:00:00+00:00'
-    assert si.convert_type('', datetime.datetime(2015, 1, 1)) == '2015-01-01T00:00:00+00:00'
-    assert si.convert_type('string', datetime.datetime(2015, 1, 1, 13, 37, 59)) == '2015-01-01T13:37:59+00:00'
-    assert si.convert_type('', datetime.datetime(2015, 1, 1, 13, 37, 59)) == '2015-01-01T13:37:59+00:00'
+    assert convert_type('string', datetime.datetime(2015, 1, 1)) == '2015-01-01T00:00:00+00:00'
+    assert convert_type('', datetime.datetime(2015, 1, 1)) == '2015-01-01T00:00:00+00:00'
+    assert convert_type('string', datetime.datetime(2015, 1, 1, 13, 37, 59)) == '2015-01-01T13:37:59+00:00'
+    assert convert_type('', datetime.datetime(2015, 1, 1, 13, 37, 59)) == '2015-01-01T13:37:59+00:00'
 
-    si = SpreadsheetInput(timezone_name='Europe/London')
-    assert si.convert_type('string', datetime.datetime(2015, 1, 1)) == '2015-01-01T00:00:00+00:00'
-    assert si.convert_type('', datetime.datetime(2015, 1, 1)) == '2015-01-01T00:00:00+00:00'
-    assert si.convert_type('string', datetime.datetime(2015, 1, 1, 13, 37, 59)) == '2015-01-01T13:37:59+00:00'
-    assert si.convert_type('', datetime.datetime(2015, 1, 1, 13, 37, 59)) == '2015-01-01T13:37:59+00:00'
-    assert si.convert_type('string', datetime.datetime(2015, 6, 1)) == '2015-06-01T00:00:00+01:00'
-    assert si.convert_type('', datetime.datetime(2015, 6, 1)) == '2015-06-01T00:00:00+01:00'
-    assert si.convert_type('string', datetime.datetime(2015, 6, 1, 13, 37, 59)) == '2015-06-01T13:37:59+01:00'
-    assert si.convert_type('', datetime.datetime(2015, 6, 1, 13, 37, 59)) == '2015-06-01T13:37:59+01:00'
+    timezone = pytz.timezone('Europe/London')
+    assert convert_type('string', datetime.datetime(2015, 1, 1), timezone) == '2015-01-01T00:00:00+00:00'
+    assert convert_type('', datetime.datetime(2015, 1, 1), timezone) == '2015-01-01T00:00:00+00:00'
+    assert convert_type('string', datetime.datetime(2015, 1, 1, 13, 37, 59), timezone) == '2015-01-01T13:37:59+00:00'
+    assert convert_type('', datetime.datetime(2015, 1, 1, 13, 37, 59), timezone) == '2015-01-01T13:37:59+00:00'
+    assert convert_type('string', datetime.datetime(2015, 6, 1), timezone) == '2015-06-01T00:00:00+01:00'
+    assert convert_type('', datetime.datetime(2015, 6, 1), timezone) == '2015-06-01T00:00:00+01:00'
+    assert convert_type('string', datetime.datetime(2015, 6, 1, 13, 37, 59), timezone) == '2015-06-01T13:37:59+01:00'
+    assert convert_type('', datetime.datetime(2015, 6, 1, 13, 37, 59), timezone) == '2015-06-01T13:37:59+01:00'

--- a/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
+++ b/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
@@ -44,12 +44,12 @@ testdata = [
     # Basic flat
     (
         [{
-            'ROOT_ID': 1,
+            'ROOT_ID': '1',
             'id': 2,
             'testA': 3
         }],
         [{
-                'ROOT_ID': 1,
+                'ROOT_ID': '1',
                 'id': 2,
                 'testA': 3
         }]
@@ -57,38 +57,38 @@ testdata = [
     # Nested
     (
         [{
-            'ROOT_ID': 1,
+            'ROOT_ID': '1',
             'id': 2,
-            'testA/testB': 3,
-            'testA/testC': 4,
+            'testO/testB': 3,
+            'testO/testC': 4,
         }],
         [{
-            'ROOT_ID': 1,
+            'ROOT_ID': '1',
             'id': 2,
-            'testA': {'testB': 3, 'testC': 4}
+            'testO': {'testB': 3, 'testC': 4}
         }]
     ),
     # Unicode
     (
         [{
             'ROOT_ID': UNICODE_TEST_STRING,
-            'testA': UNICODE_TEST_STRING
+            'testU': UNICODE_TEST_STRING
         }],
         [{
             'ROOT_ID': UNICODE_TEST_STRING,
-            'testA': UNICODE_TEST_STRING
+            'testU': UNICODE_TEST_STRING
         }]
     ),
     # Single item array
     (
         [{
-            'ROOT_ID': 1,
+            'ROOT_ID': '1',
             'id': 2,
-            'testA[]/id': 3,
-            'testA[]/testB': 4
+            'testL/0/id': 3,
+            'testL/0/testB': 4
         }],
         [{
-            'ROOT_ID': 1, 'id': 2, 'testA': [{
+            'ROOT_ID': '1', 'id': 2, 'testL': [{
                 'id': 3, 'testB': 4
             }]
         }]
@@ -97,12 +97,12 @@ testdata = [
     (
         [{
             'ROOT_ID': '1',
-            'testA[]/id': '2',
-            'testA[]/testB': '3',
+            'testL/0/id': '2',
+            'testL/0/testB': '3',
         }],
         [{
             'ROOT_ID': '1',
-            'testA': [{
+            'testL': [{
                 'id': '2',
                 'testB': '3'
             }]
@@ -112,11 +112,11 @@ testdata = [
     (
         [{
             'ROOT_ID': '',
-            'id:integer': '',
-            'testA:number': '',
-            'testB:boolean': '',
-            'testC:array': '',
-            'testD:string': '',
+            'id': '',
+            'testA': '',
+            'testB': '',
+            'testC': '',
+            'testD': '',
             'testE': '',
         }],
         []
@@ -125,11 +125,11 @@ testdata = [
     (
         [{
             'ROOT_ID': 1,
-            'id:integer': '',
-            'testA:number': '',
-            'testB:boolean': '',
-            'testC:array': '',
-            'testD:string': '',
+            'id': '',
+            'testA': '',
+            'testB': '',
+            'testC': '',
+            'testD': '',
             'testE': '',
         }],
         [{
@@ -282,7 +282,7 @@ testdata_titles = [
             'ROOT_ID': 1,
             'id': 2,
             'testR': [{
-                'id': 3, 'testB': 4
+                'id': '3', 'testB': '4'
             }]
         }]
     ),
@@ -314,8 +314,8 @@ testdata_titles = [
             'ROOT_ID': 1,
             'id': 2,
             'testR': [{
-                'id': 3,
-                'testC': 4
+                'id': '3',
+                'testC': '4'
             }]
         }]
     ),
@@ -331,7 +331,7 @@ testdata_titles = [
             'ROOT_ID': 1,
             'id': 2,
             'testR': [{
-                'testC': 3,
+                'testC': '3',
                 'Not in schema': 4
             }]
         }]
@@ -392,15 +392,16 @@ def test_unflatten(convert_titles, use_schema, root_id, root_id_kwargs, input_li
         main_sheet_name='custom_main',
         **extra_kwargs)
     spreadsheet_input.read_sheets()
-    if convert_titles:
-        parser = SchemaParser(
-            root_schema_dict=create_schema(root_id) if use_schema else {},
-            main_sheet_name='custom_main',
-            root_id=root_id,
-            rollup=True
-        )
-        parser.parse()
-        spreadsheet_input.parser = parser
+
+    parser = SchemaParser(
+        root_schema_dict=create_schema(root_id) if use_schema else {"properties": {}},
+        main_sheet_name='custom_main',
+        root_id=root_id,
+        rollup=True
+    )
+    parser.parse()
+    spreadsheet_input.parser = parser
+
     expected_output_list = [
         inject_root_id(root_id, expected_output_dict) for expected_output_dict in expected_output_list
     ]

--- a/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
+++ b/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
@@ -246,6 +246,13 @@ def create_schema(root_id):
                 'title': UNICODE_TEST_STRING,
                 'type': 'string',
             },
+            'testSA': {
+                'title': 'SA title',
+                'type': 'array',
+                'items': {
+                    'type': 'string'
+                }
+            }
         }
     }
     if root_id:
@@ -447,7 +454,32 @@ testdata_titles = [
         [{
             'ROOT_ID': 1
         }]
-    )
+    ),
+    # Test arrays of strings
+    (
+        [{
+            'ROOT_ID_TITLE': 1,
+            'Identifier': 2,
+            'SA title': 'a',
+        }],
+        [{
+            'ROOT_ID': 1,
+            'id': 2,
+            'testSA': [ 'a' ],
+        }]
+    ),
+    (
+        [{
+            'ROOT_ID_TITLE': 1,
+            'Identifier': 2,
+            'SA title': 'a;b',
+        }],
+        [{
+            'ROOT_ID': 1,
+            'id': 2,
+            'testSA': [ 'a', 'b' ],
+        }]
+    ),
 ]
 
 ROOT_ID_PARAMS =     [

--- a/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
+++ b/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
@@ -138,6 +138,60 @@ testdata = [
     )
 ]
 
+testdata_pointer = [
+    # Single item array without json numbering
+    (
+        [{
+            'ROOT_ID': '1',
+            'testR/id': '2',
+            'testR/testB': '3',
+            'testR/testX': '3',
+        }],
+        [{
+            'ROOT_ID': '1',
+            'testR': [{
+                'id': '2',
+                'testB': '3',
+                'testX': '3'
+            }]
+        }]
+    ),
+    # Multi item array one with varied numbering 
+    (
+        [{
+            'ROOT_ID': '1',
+            'testR/id': '-1',
+            'testR/testB': '-1',
+            'testR/testX': '-2',
+            'testR/0/id': '0',
+            'testR/0/testB': '1',
+            'testR/0/testX': '1',
+            'testR/5/id': '5',
+            'testR/5/testB': '5',
+            'testR/5/testX': '6',
+        }],
+        [{
+            'ROOT_ID': '1',
+            'testR': [{
+                'id': '-1',
+                'testB': '-1',
+                'testX': '-2'
+            },
+            {
+                'id': '0',
+                'testB': '1',
+                'testX': '1'
+            },
+            {
+                'id': '5',
+                'testB': '5',
+                'testX': '6'
+            }
+            ]
+        }]
+    ),
+]
+
 def create_schema(root_id):
     schema = {
         'properties': {
@@ -336,6 +390,36 @@ testdata_titles = [
             }]
         }]
     ),
+    # Multi item array, allow numbering
+    (
+        [{
+            'ROOT_ID_TITLE': 1,
+            'Identifier': 2,
+            'R title:C title': 3,
+            'R title:Not in schema': 4,
+            'R title:0:C title': 5,
+            'R title:0:Not in schema': 6,
+            'R title:5:C title': 7,
+            'R title:5:Not in schema': 8,
+        }],
+        [{
+            'ROOT_ID': 1,
+            'id': 2,
+            'testR': [{
+                'testC': '3',
+                'Not in schema': 4
+            },
+            {
+                'testC': '5',
+                'Not in schema': 6
+            },
+            {
+                'testC': '7',
+                'Not in schema': 8
+            }
+            ]
+        }]
+    ),
     # Empty
     (
         [{
@@ -412,6 +496,13 @@ def test_unflatten(convert_titles, use_schema, root_id, root_id_kwargs, input_li
     # We expect no warnings
     if not convert_titles: # TODO what are the warnings here
         assert recwarn.list == []
+
+
+@pytest.mark.parametrize('convert_titles', [True, False])
+@pytest.mark.parametrize('root_id,root_id_kwargs', ROOT_ID_PARAMS)
+@pytest.mark.parametrize('input_list,expected_output_list', testdata_pointer)
+def test_unflatten_pointer(convert_titles, root_id, root_id_kwargs, input_list, expected_output_list, recwarn):
+    return test_unflatten(convert_titles=convert_titles, use_schema=True, root_id=root_id, root_id_kwargs=root_id_kwargs, input_list=input_list, expected_output_list=expected_output_list, recwarn=recwarn)
 
 
 @pytest.mark.parametrize('input_list,expected_output_list', testdata_titles)

--- a/flattentool/tests/test_output.py
+++ b/flattentool/tests/test_output.py
@@ -34,7 +34,8 @@ def test_blank_sheets(tmpdir):
     wb = openpyxl.load_workbook(tmpdir.join('release.xlsx').strpath)
     assert wb.get_sheet_names() == ['release']
     assert len(wb['release'].rows) == 1
-    assert len(wb['release'].rows[0]) == 0
+    assert len(wb['release'].rows[0]) == 1
+    assert wb['release'].rows[0][0].value == None
     
     # Check CSV is Empty
     assert tmpdir.join('release').listdir() == [ tmpdir.join('release').join('release.csv') ]


### PR DESCRIPTION
Adds the following

* A new method to unflatten the main page.
* Adds flattened property to Schema parser that more reflects json
 pointer removes
* Use schema to convert types

The new unflatten should produce output the same as before meaning that
multiple sheets will still work.
If no schema is supplied then fallback to old behaviour with types.

Various tests had to be fixed as if the schema says the field is a
string then it converts it.

Breaking change: If schema is supplied and the main table uses ":type"
notation then it will mistake this is a subobject not a types.

<!---
@huboard:{"order":2.6738357662361523,"milestone_order":89,"custom_state":""}
-->
