### PR TITLE
[#91] Strip types from main sheet

### DIFF
--- a/flattentool/__init__.py
+++ b/flattentool/__init__.py
@@ -121,7 +121,7 @@ def unflatten(input_name, base_json=None, input_format=None, output_name='releas
         main_sheet_name=main_sheet_name,
         root_id=root_id,
         convert_titles=convert_titles)
-    if convert_titles:
+    if schema:
         parser = SchemaParser(schema_filename=schema, main_sheet_name=main_sheet_name, rollup=True, root_id=root_id)
         parser.parse()
         spreadsheet_input.parser = parser

--- a/flattentool/schema.py
+++ b/flattentool/schema.py
@@ -101,7 +101,7 @@ class SchemaParser(object):
                 else:
                     self.main_sheet.append(title)
             else:
-                self.main_sheet.append(field)
+                self.main_sheet.append(field.split(":")[0])
 
     def parse_schema_dict(self, parent_name, parent_path, schema_dict, parent_id_fields=None, title_lookup=None):
         if parent_path:

--- a/flattentool/tests/test_json_input.py
+++ b/flattentool/tests/test_json_input.py
@@ -321,9 +321,9 @@ class TestParseUsingSchema(object):
             schema_parser=schema_parser
         )
         parser.parse()
-        assert list(parser.main_sheet) == [ 'c:array' ]
+        assert list(parser.main_sheet) == [ 'c' ]
         assert parser.main_sheet.lines == [
-                {'c:array': 'd'}
+                {'c': 'd'}
         ]
         assert len(parser.sub_sheets) == 0
 

--- a/flattentool/tests/test_schema_parser.py
+++ b/flattentool/tests/test_schema_parser.py
@@ -280,7 +280,7 @@ def test_simple_array():
         main_sheet_name='custom_main_sheet_name'
     )
     parser.parse()
-    assert set(parser.main_sheet) == set(['testA:array'])
+    assert set(parser.main_sheet) == set(['testA'])
 
 
 def test_nested_simple_array():
@@ -301,7 +301,7 @@ def test_nested_simple_array():
         main_sheet_name='custom_main_sheet_name'
     )
     parser.parse()
-    assert set(parser.main_sheet) == set(['testA:array'])
+    assert set(parser.main_sheet) == set(['testA'])
 
 
 def test_references_sheet_names(tmpdir):


### PR DESCRIPTION
Just strip types in schema to remove them from flattening and template
generation.

Change unflatten behaviour to generate schema when titles are not being
used.