### PR TITLE
Changes to cli and Python function interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Can be converted to/from a spreadsheet like [examples/simple/main.csv](examples/
 Using the commands:
 
 ```
-flatten-tool unflatten -f csv examples/simple --main-sheet-name main --root-id='' -o examples/simple.json
-flatten-tool flatten -f csv examples/simple.json --main-sheet-name main --root-list-path main -o examples/simple
+flatten-tool unflatten -f csv examples/simple --root-id='' -o examples/simple.json
+flatten-tool flatten -f csv examples/simple.json -o examples/simple
 ```
 
 
@@ -123,8 +123,8 @@ These are also the spreadsheets that flatten-tool's `flatten` (JSON to Spreadshe
 Commands used to generate this:
 
 ```
-flatten-tool unflatten -f csv examples/array_multisheet --main-sheet-name main --root-id='' -o examples/array_multisheet.json
-flatten-tool flatten -f csv examples/array.json --main-sheet-name main --root-list-path main -o examples/array_multisheet
+flatten-tool unflatten -f csv examples/array_multisheet --root-id='' -o examples/array_multisheet.json
+flatten-tool flatten -f csv examples/array.json -o examples/array_multisheet
 ```
 
 However, there are other "shapes" of spreadsheet that can produce the same JSON.
@@ -137,7 +137,7 @@ New columns for each item of the array:
 |7|8|9|10|11|12|
 
 ```
-flatten-tool unflatten -f csv examples/array_pointer --main-sheet-name main --root-id='' -o examples/array.json
+flatten-tool unflatten -f csv examples/array_pointer --root-id='' -o examples/array.json
 ```
 
 Repeated rows:
@@ -151,7 +151,7 @@ Repeated rows:
 
 
 ```
-flatten-tool unflatten -f csv examples/array_repeat_rows --main-sheet-name main --root-id='' -o examples/array.json
+flatten-tool unflatten -f csv examples/array_repeat_rows --root-id='' -o examples/array.json
 ```
 
 
@@ -367,20 +367,20 @@ And populate this with the package information for your release.
 
 Then, for a populated xlsx template in (in release_populated.xlsx):
 
-    flatten-tool unflatten release_populated.xlsx --base-json base.json --input-format xlsx --output-name release.json
+    flatten-tool unflatten release_populated.xlsx --base-json base.json --input-format xlsx --output-name release.json --root-list-path='releases'
 
 Or for populated CSV files (in the release_populated directory):
 
-    flatten-tool unflatten release_populated --base-json base.json --input-format csv --output-name release.json
+    flatten-tool unflatten release_populated --base-json base.json --input-format csv --output-name release.json --root-list-path='releases'
 
 These produce a release.json file based on the data in the spreadsheets.
 
 
 ### Converting a JSON file to a spreadsheet
 
-    flatten-tool flatten input.json --main-sheet-name releases --output-name unflattened
+    flatten-tool flatten input.json --main-sheet-name releases --output-name flattened --root-list-path='releases'
 
-This will create `unflattened.xlsx` and a `unflattened/` directory of csv files.
+This will create `flattened.xlsx` and a `flattened/` directory of csv files.
 
 ## Usage for 360Giving
 
@@ -392,7 +392,7 @@ to the current directory.
 
     flatten-tool create-template --root-id='' --output-format all --output-name 360giving-template --schema 360-giving-schema.json --main-sheet-name grants --rollup --use-titles
 
-    flatten-tool unflatten --root-id='' -o out.json -f xlsx --main-sheet-name=grants input.xlsx --schema 360-giving-schema.json --convert-titles
+    flatten-tool unflatten --root-id='' -o out.json -f xlsx input.xlsx --schema 360-giving-schema.json --convert-titles --root-list-path='grants'
 
 
 Running the tests

--- a/flattentool/__init__.py
+++ b/flattentool/__init__.py
@@ -38,7 +38,7 @@ def create_template(schema, output_name='releases', output_format='all', main_sh
         raise Exception('The requested format is not available')
 
 
-def flatten(input_name, schema=None, output_name='releases', output_format='all', main_sheet_name='main', root_list_path='releases', rollup=False, root_id='ocid', use_titles=False, **_):
+def flatten(input_name, schema=None, output_name='releases', output_format='all', main_sheet_name='main', root_list_path='main', rollup=False, root_id='ocid', use_titles=False, **_):
     """
     Flatten a nested structure (JSON) to a flat structure (spreadsheet - csv or xlsx).
 

--- a/flattentool/__init__.py
+++ b/flattentool/__init__.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from collections import OrderedDict
 
 
-def create_template(schema, output_name='releases', output_format='all', main_sheet_name='main', flatten=False, rollup=False, root_id='ocid', use_titles=False, **_):
+def create_template(schema, output_name='template', output_format='all', main_sheet_name='main', flatten=False, rollup=False, root_id='ocid', use_titles=False, **_):
     """
     Creates template file(s) from given inputs
     This function is built to deal with commandline input and arguments
@@ -38,7 +38,7 @@ def create_template(schema, output_name='releases', output_format='all', main_sh
         raise Exception('The requested format is not available')
 
 
-def flatten(input_name, schema=None, output_name='releases', output_format='all', main_sheet_name='main', root_list_path='main', rollup=False, root_id='ocid', use_titles=False, **_):
+def flatten(input_name, schema=None, output_name='flattened', output_format='all', main_sheet_name='main', root_list_path='main', rollup=False, root_id='ocid', use_titles=False, **_):
     """
     Flatten a nested structure (JSON) to a flat structure (spreadsheet - csv or xlsx).
 
@@ -100,7 +100,7 @@ def decimal_default(o):
     raise TypeError(repr(o) + " is not JSON serializable")
 
 
-def unflatten(input_name, base_json=None, input_format=None, output_name='releases.json',
+def unflatten(input_name, base_json=None, input_format=None, output_name='unflattened.json',
               root_list_path='main', encoding='utf8', timezone_name='UTC',
               root_id='ocid', schema='', convert_titles=False, cell_source_map=None,
               heading_source_map=None, **_):

--- a/flattentool/__init__.py
+++ b/flattentool/__init__.py
@@ -17,7 +17,7 @@ def create_template(schema, output_name='releases', output_format='all', main_sh
 
     """
 
-    parser = SchemaParser(schema_filename=schema, main_sheet_name=main_sheet_name, rollup=rollup, root_id=root_id, use_titles=use_titles)
+    parser = SchemaParser(schema_filename=schema, rollup=rollup, root_id=root_id, use_titles=use_titles)
     parser.parse()
 
     def spreadsheet_output(spreadsheet_output_class, name):
@@ -49,8 +49,7 @@ def flatten(input_name, schema=None, output_name='releases', output_format='all'
             schema_filename=schema,
             rollup=rollup,
             root_id=root_id,
-            use_titles=use_titles,
-            main_sheet_name=main_sheet_name)
+            use_titles=use_titles)
         schema_parser.parse()
     else:
         schema_parser = None
@@ -58,7 +57,6 @@ def flatten(input_name, schema=None, output_name='releases', output_format='all'
         json_filename=input_name,
         root_list_path=root_list_path,
         schema_parser=schema_parser,
-        main_sheet_name=main_sheet_name,
         root_id=root_id,
         use_titles=use_titles)
     parser.parse()
@@ -103,7 +101,7 @@ def decimal_default(o):
 
 
 def unflatten(input_name, base_json=None, input_format=None, output_name='releases.json',
-              main_sheet_name='releases', encoding='utf8', timezone_name='UTC',
+              root_list_path='main', encoding='utf8', timezone_name='UTC',
               root_id='ocid', schema='', convert_titles=False, cell_source_map=None,
               heading_source_map=None, **_):
     """
@@ -119,11 +117,11 @@ def unflatten(input_name, base_json=None, input_format=None, output_name='releas
     spreadsheet_input = spreadsheet_input_class(
         input_name=input_name,
         timezone_name=timezone_name,
-        main_sheet_name=main_sheet_name,
+        root_list_path=root_list_path,
         root_id=root_id,
         convert_titles=convert_titles)
     if schema:
-        parser = SchemaParser(schema_filename=schema, main_sheet_name=main_sheet_name, rollup=True, root_id=root_id)
+        parser = SchemaParser(schema_filename=schema, rollup=True, root_id=root_id)
         parser.parse()
         spreadsheet_input.parser = parser
     spreadsheet_input.encoding = encoding
@@ -135,7 +133,7 @@ def unflatten(input_name, base_json=None, input_format=None, output_name='releas
         base = OrderedDict()
     if WITH_CELLS:
         result, cell_source_map_data, heading_source_map_data = spreadsheet_input.fancy_unflatten()
-        base[main_sheet_name] = list(result)
+        base[root_list_path] = list(result)
         with codecs.open(output_name, 'w', encoding='utf-8') as fp:
             json.dump(base, fp, indent=4, default=decimal_default, ensure_ascii=False)
         if cell_source_map:
@@ -146,7 +144,7 @@ def unflatten(input_name, base_json=None, input_format=None, output_name='releas
                 json.dump(heading_source_map_data, fp, indent=4, default=decimal_default, ensure_ascii=False)
     else:
         result = spreadsheet_input.unflatten()
-        base[main_sheet_name] = list(result)
+        base[root_list_path] = list(result)
         with codecs.open(output_name, 'w', encoding='utf-8') as fp:
             json.dump(base, fp, indent=4, default=decimal_default, ensure_ascii=False)
 

--- a/flattentool/cli.py
+++ b/flattentool/cli.py
@@ -76,7 +76,7 @@ def create_parser():
         help="Name of the outputted file. Will have an extension appended if format is all.")
     parser_flatten.add_argument(
         "--root-list-path",
-        help="Path of the root list, defaults to releases")
+        help="Path of the root list, defaults to main")
     parser_flatten.add_argument(
         "--rollup",
         action='store_true',
@@ -103,8 +103,8 @@ def create_parser():
         "-b", "--base-json",
         help="A base json file to populate the releases key in.")
     parser_unflatten.add_argument(
-        "-m", "--main-sheet-name",
-        help="The name of the main sheet. Defaults to releases")
+        "-m", "--root-list-path",
+        help="The path in the JSON that will contain the unflattened list. Defaults to main.")
     parser_unflatten.add_argument(
         "-e", "--encoding",
         help="Encoding of the input file(s) (only relevant for CSV). Defaults to utf8.")

--- a/flattentool/cli.py
+++ b/flattentool/cli.py
@@ -101,7 +101,7 @@ def create_parser():
         required=True)
     parser_unflatten.add_argument(
         "-b", "--base-json",
-        help="A base json file to populate the releases key in.")
+        help="A base json file to populate with the unflattened data.")
     parser_unflatten.add_argument(
         "-m", "--root-list-path",
         help="The path in the JSON that will contain the unflattened list. Defaults to main.")
@@ -110,7 +110,7 @@ def create_parser():
         help="Encoding of the input file(s) (only relevant for CSV). Defaults to utf8.")
     parser_unflatten.add_argument(
         "-o", "--output-name",
-        help="Name of the outputted file. Will have an extension appended as appropriate. Defaults to releases")
+        help="Name of the outputted file. Will have an extension appended as appropriate. Defaults to unflattened.json")
     parser_unflatten.add_argument(
         "-c", "--cell-source-map",
         help="Path to write a cell source map to. Will have an extension appended as appropriate.")

--- a/flattentool/input.py
+++ b/flattentool/input.py
@@ -369,7 +369,7 @@ class XLSXInput(SpreadsheetInput):
     def read_sheets(self):
         self.workbook = openpyxl.load_workbook(self.input_name, data_only=True)
 
-        self.sheet_names_map = {sheet_name: sheet_name for sheet_name in self.workbook.get_sheet_names()}
+        self.sheet_names_map = OrderedDict((sheet_name, sheet_name) for sheet_name in self.workbook.get_sheet_names())
 
         sheet_names = list(self.sheet_names_map.keys())
         self.sub_sheet_names = sheet_names

--- a/flattentool/json_input.py
+++ b/flattentool/json_input.py
@@ -47,10 +47,9 @@ class JSONParser(object):
     # Named for consistency with schema.SchemaParser, but not sure it's the most appropriate name.
     # Similarily with methods like parse_json_dict
 
-    def __init__(self, json_filename=None, root_json_dict=None, main_sheet_name='main', schema_parser=None, root_list_path=None, root_id='ocid', use_titles=False):
+    def __init__(self, json_filename=None, root_json_dict=None, schema_parser=None, root_list_path=None, root_id='ocid', use_titles=False):
         self.sub_sheets = {}
         self.main_sheet = Sheet()
-        self.main_sheet_name = main_sheet_name
         self.root_list_path = root_list_path
         self.root_id = root_id
         self.use_titles = use_titles

--- a/flattentool/schema.py
+++ b/flattentool/schema.py
@@ -62,11 +62,10 @@ class TitleLookup(UserDict):
 class SchemaParser(object):
     """Parse the fields of a JSON schema into a flattened structure."""
 
-    def __init__(self, schema_filename=None, root_schema_dict=None, main_sheet_name='main', rollup=False, root_id='ocid', use_titles=False):
+    def __init__(self, schema_filename=None, root_schema_dict=None, rollup=False, root_id='ocid', use_titles=False):
         self.sub_sheets = {}
         self.main_sheet = Sheet()
         self.sub_sheet_mapping = {}
-        self.main_sheet_name = main_sheet_name
         self.rollup = rollup
         self.root_id = root_id
         self.use_titles = use_titles

--- a/flattentool/tests/test_input_SpreadsheetInput.py
+++ b/flattentool/tests/test_input_SpreadsheetInput.py
@@ -95,12 +95,6 @@ class TestInputFailure(object):
             with pytest.raises(OSError):
                 csvinput.read_sheets()
 
-    def test_csv_no_files(self, tmpdir):
-        csvinput = CSVInput(input_name=tmpdir.strpath)
-        with pytest.raises(ValueError) as e:
-            csvinput.read_sheets()
-        assert 'Main sheet' in text_type(e) and 'not found' in text_type(e)
-
     def test_xlsx_no_file(self, tmpdir):
         xlsxinput = XLSXInput(input_name=tmpdir.strpath.join('test.xlsx'))
         if sys.version > '3':

--- a/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
+++ b/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
@@ -521,13 +521,11 @@ def test_unflatten(convert_titles, use_schema, root_id, root_id_kwargs, input_li
                 inject_root_id(root_id, input_row) for input_row in input_list
             ]
         },
-        main_sheet_name='custom_main',
         **extra_kwargs)
     spreadsheet_input.read_sheets()
 
     parser = SchemaParser(
         root_schema_dict=create_schema(root_id) if use_schema else {"properties": {}},
-        main_sheet_name='custom_main',
         root_id=root_id,
         rollup=True
     )

--- a/flattentool/tests/test_input_SpreadsheetInput_unflatten_mulitplesheets.py
+++ b/flattentool/tests/test_input_SpreadsheetInput_unflatten_mulitplesheets.py
@@ -97,8 +97,8 @@ class TestUnflatten(object):
 
     def test_basic_two_sub_sheets(self):
         spreadsheet_input = ListInput(
-            sheets={
-                'custom_main': [
+            sheets=OrderedDict([
+                ('custom_main', [
                     OrderedDict([
                         ('ocid', 1),
                         ('id', 2),
@@ -107,24 +107,24 @@ class TestUnflatten(object):
                         ('ocid', 1),
                         ('id', 6),
                     ])
-                ],
-                'sub1': [
+                ]),
+                ('sub1', [
                     {
                         'ocid': 1,
                         'id': 2,
                         'sub1Field/0/id': 3,
                         'sub1Field/0/testA': 4,
                     }
-                ],
-                'sub2': [
+                ]),
+                ('sub2', [
                     {
                         'ocid': 1,
                         'id': 2,
                         'sub1Field/0/id': 3,
                         'sub1Field/0/sub2Field/0/testB': 5,
                     }
-                ]
-            }
+                ])
+            ])
             )
         spreadsheet_input.read_sheets()
         unflattened = list(spreadsheet_input.unflatten())
@@ -204,14 +204,14 @@ class TestUnflatten(object):
 
     def test_unmatched_id(self, recwarn):
         spreadsheet_input = ListInput(
-            sheets={
-                'custom_main': [
+            sheets=OrderedDict([
+                ('custom_main', [
                     {
                         'ocid': 1,
                         'id': 2,
                     }
-                ],
-                'sub': [
+                ]),
+                ('sub', [
                     {
                         'ocid': 1,
                         'id': 100,
@@ -224,8 +224,8 @@ class TestUnflatten(object):
                         'subField/0/id': 3,
                         'subField/0/testA': 5,
                     }
-                ]
-            }
+                ])
+            ])
             )
         spreadsheet_input.read_sheets()
         unflattened = list(spreadsheet_input.unflatten())
@@ -285,24 +285,25 @@ class TestUnflattenRollup(object):
 
     def test_conflicting_rollup(self, recwarn):
         spreadsheet_input = ListInput(
-            sheets={
-                'main': [
+            sheets=OrderedDict([
+                ('main', [
                     {
                         'ocid': 1,
                         'id': 2,
                         'testA/0/id': 3,
                         'testA/0/testB': 4
                     }
-                ],
-                'testA': [
+                ]),
+                ('testA', [
                     {
                         'ocid': 1,
                         'id': 2,
                         'testA/0/id': 3,
                         'testA/0/testB': 5,
                     }
-                ]
-            },
+                ])
+            ])
+
         )
         spreadsheet_input.read_sheets()
         unflattened = list(spreadsheet_input.unflatten())
@@ -313,9 +314,7 @@ class TestUnflattenRollup(object):
                 'testA': [{
                     'id': 3,
                     'testB': 4
-                    # We currently know that testB will be 4 because the main
-                    # sheet is currently always parsed first, but this may change:
-                    # https://github.com/OpenDataServices/flatten-tool/issues/96
+                    # (Since sheets are parsed in the order they appear, and the first value is used).
                 }]
             }
         ]
@@ -395,30 +394,30 @@ class TestUnflattenCustomRootID(object):
 
     def test_basic_two_sub_sheets(self):
         spreadsheet_input = ListInput(
-            sheets={
-                'custom_main': [
+            sheets=OrderedDict([
+                ('custom_main', [
                     OrderedDict([
                         ('custom', 1),
                         ('id', 2),
                     ])
-                ],
-                'sub1': [
+                ]),
+                ('sub1', [
                     {
                         'custom': 1,
                         'id': 2,
                         'sub1Field/0/id': 3,
                         'sub1Field/0/testA': 4,
                     }
-                ],
-                'sub2': [
+                ]),
+                ('sub2', [
                     {
                         'custom': 1,
                         'id': 2,
                         'sub1Field/0/id': 3,
                         'sub1Field/0/sub2Field/0/testB': 5,
                     }
-                ]
-            },
+                ])
+            ]),
             root_id='custom')
         spreadsheet_input.read_sheets()
         unflattened = list(spreadsheet_input.unflatten())
@@ -484,27 +483,27 @@ class TestUnflattenNoRootID(object):
 
     def test_basic_two_sub_sheets(self):
         spreadsheet_input = ListInput(
-            sheets={
-                'custom_main': [
+            sheets=OrderedDict([
+                ('custom_main', [
                     OrderedDict([
                         ('id', 2),
                     ])
-                ],
-                'sub1': [
+                ]),
+                ('sub1', [
                     {
                         'id': 2,
                         'sub1Field/0/id': 3,
                         'sub1Field/0/testA': 4,
                     }
-                ],
-                'sub2': [
+                ]),
+                ('sub2', [
                     {
                         'id': 2,
                         'sub1Field/0/id': 3,
                         'sub1Field/0/sub2Field/0/testB': 5,
                     }
-                ]
-            },
+                ])
+            ]),
             root_id='')
         spreadsheet_input.read_sheets()
         unflattened = list(spreadsheet_input.unflatten())

--- a/flattentool/tests/test_input_SpreadsheetInput_unflatten_mulitplesheets.py
+++ b/flattentool/tests/test_input_SpreadsheetInput_unflatten_mulitplesheets.py
@@ -40,8 +40,8 @@ class TestUnflatten(object):
                         'subField/0/testA': 4,
                     }
                 ]
-            },
-            main_sheet_name='custom_main')
+            }
+            )
         spreadsheet_input.read_sheets()
         assert list(spreadsheet_input.unflatten()) == [
             {
@@ -84,8 +84,8 @@ class TestUnflatten(object):
                         'testA/subField/0/testC': 5,
                     }
                 ]
-            },
-            main_sheet_name='custom_main')
+            }
+            )
         spreadsheet_input.read_sheets()
         assert list(spreadsheet_input.unflatten()) == [
             {'ocid': 1, 'id': 2, 'testA': {
@@ -124,8 +124,8 @@ class TestUnflatten(object):
                         'sub1Field/0/sub2Field/0/testB': 5,
                     }
                 ]
-            },
-            main_sheet_name='custom_main')
+            }
+            )
         spreadsheet_input.read_sheets()
         unflattened = list(spreadsheet_input.unflatten())
         assert len(unflattened) == 2
@@ -162,8 +162,8 @@ class TestUnflatten(object):
                         'subField/0/testA/id': 4,
                     }
                 ]
-            },
-            main_sheet_name='custom_main')
+            }
+            )
         spreadsheet_input.read_sheets()
         assert list(spreadsheet_input.unflatten()) == [
             {'ocid': 1, 'id': 2, 'subField': [{'id': 3, 'testA': {'id': 4}}]}
@@ -192,8 +192,8 @@ class TestUnflatten(object):
                         'subField/0/testA': 5,
                     }
                 ]
-            },
-            main_sheet_name='custom_main')
+            }
+            )
         spreadsheet_input.read_sheets()
         unflattened = list(spreadsheet_input.unflatten())
         # Check that following lines are parsed correctly
@@ -225,8 +225,8 @@ class TestUnflatten(object):
                         'subField/0/testA': 5,
                     }
                 ]
-            },
-            main_sheet_name='custom_main')
+            }
+            )
         spreadsheet_input.read_sheets()
         unflattened = list(spreadsheet_input.unflatten())
         assert unflattened == [
@@ -268,7 +268,6 @@ class TestUnflattenRollup(object):
                     }
                 ]
             },
-            main_sheet_name='main'
         )
         spreadsheet_input.read_sheets()
         unflattened = list(spreadsheet_input.unflatten())
@@ -304,7 +303,6 @@ class TestUnflattenRollup(object):
                     }
                 ]
             },
-            main_sheet_name='main'
         )
         spreadsheet_input.read_sheets()
         unflattened = list(spreadsheet_input.unflatten())
@@ -341,8 +339,8 @@ class TestUnflattenEmpty(object):
                         'testD': '',
                     }
                 ]
-            },
-            main_sheet_name='custom_main')
+            }
+            )
         spreadsheet_input.read_sheets()
         output = list(spreadsheet_input.unflatten())
         assert len(output) == 0
@@ -366,7 +364,6 @@ class TestUnflattenCustomRootID(object):
                     }
                 ]
             },
-            main_sheet_name='custom_main',
             root_id='custom')
         spreadsheet_input.read_sheets()
         assert list(spreadsheet_input.unflatten()) == [
@@ -390,7 +387,6 @@ class TestUnflattenCustomRootID(object):
                     }
                 ]
             },
-            main_sheet_name='custom_main',
             root_id='custom')
         spreadsheet_input.read_sheets()
         assert list(spreadsheet_input.unflatten()) == [
@@ -423,7 +419,6 @@ class TestUnflattenCustomRootID(object):
                     }
                 ]
             },
-            main_sheet_name='custom_main',
             root_id='custom')
         spreadsheet_input.read_sheets()
         unflattened = list(spreadsheet_input.unflatten())
@@ -460,7 +455,6 @@ class TestUnflattenNoRootID(object):
                     }
                 ]
             },
-            main_sheet_name='custom_main',
             root_id='')
         spreadsheet_input.read_sheets()
         assert list(spreadsheet_input.unflatten()) == [
@@ -482,7 +476,6 @@ class TestUnflattenNoRootID(object):
                     }
                 ]
             },
-            main_sheet_name='custom_main',
             root_id='')
         spreadsheet_input.read_sheets()
         assert list(spreadsheet_input.unflatten()) == [
@@ -512,7 +505,6 @@ class TestUnflattenNoRootID(object):
                     }
                 ]
             },
-            main_sheet_name='custom_main',
             root_id='')
         spreadsheet_input.read_sheets()
         unflattened = list(spreadsheet_input.unflatten())
@@ -550,8 +542,8 @@ def test_with_schema():
                     'testR/testB': 4 # test that we can infer this an array from schema
                 }
             ]
-        },
-        main_sheet_name='custom_main')
+        }
+        )
     spreadsheet_input.read_sheets()
 
     parser = SchemaParser(
@@ -568,7 +560,6 @@ def test_with_schema():
                 },
             }
         },
-        main_sheet_name='custom_main',
         root_id='ocid',
         rollup=True
     )

--- a/flattentool/tests/test_roundtrip.py
+++ b/flattentool/tests/test_roundtrip.py
@@ -13,6 +13,7 @@ def test_roundtrip(tmpdir, output_format):
         output_name=tmpdir.join('flattened').strpath+'.'+output_format,
         output_format=output_format,
         schema='flattentool/tests/fixtures/release-schema.json',
+        root_list_path='releases',
         main_sheet_name='releases')
     unflatten(
         input_name=tmpdir.join('flattened').strpath+'.'+output_format,
@@ -20,7 +21,7 @@ def test_roundtrip(tmpdir, output_format):
         input_format=output_format,
         base_json=base_name,
         schema='flattentool/tests/fixtures/release-schema.json',
-        main_sheet_name='releases')
+        root_list_path='releases')
     original_json = json.load(open(input_name))
     roundtripped_json = json.load(tmpdir.join('roundtrip.json'))
 
@@ -41,16 +42,15 @@ def test_roundtrip_360(tmpdir, output_format, use_titles):
         output_name=tmpdir.join('flattened').strpath+'.'+output_format,
         output_format=output_format,
         schema='flattentool/tests/fixtures/360-giving-schema.json',
-        main_sheet_name='grants',
         root_list_path='grants',
         root_id='',
-        use_titles=use_titles)
+        use_titles=use_titles,
+        main_sheet_name='releases')
     unflatten(
         input_name=tmpdir.join('flattened').strpath+'.'+output_format,
         output_name=tmpdir.join('roundtrip.json').strpath,
         input_format=output_format,
         schema='flattentool/tests/fixtures/360-giving-schema.json',
-        main_sheet_name='grants',
         root_list_path='grants',
         root_id='',
         convert_titles=use_titles)

--- a/flattentool/tests/test_schema_parser.py
+++ b/flattentool/tests/test_schema_parser.py
@@ -252,8 +252,7 @@ class TestSubSheetMainID(object):
                         'properties': object_in_array_example_properties('Btest', 'Ctest')
                     }
                 }
-            },
-            main_sheet_name='custom_main_sheet_name'
+            }
         )
         parser.parse()
         assert set(parser.main_sheet) == set(['id', 'Atest/id'])
@@ -276,8 +275,7 @@ def test_simple_array():
                     }
                 }
             }
-        },
-        main_sheet_name='custom_main_sheet_name'
+        }
     )
     parser.parse()
     assert set(parser.main_sheet) == set(['Atest'])
@@ -297,8 +295,7 @@ def test_nested_simple_array():
                     }
                 }
             }
-        },
-        main_sheet_name='custom_main_sheet_name'
+        }
     )
     parser.parse()
     assert set(parser.main_sheet) == set(['Atest'])


### PR DESCRIPTION
* main-sheet-name/main_sheet_name is removed for unflattening. #96 
 * This means sheet names no longer matter at all for unflattening, which fixes https://github.com/OpenDataServices/cove/issues/377
 * Some of the merging is dependent on order, so we use the order in the spreadsheet, or for CSV files, alphabetically.
* root-list-path/root_list_path is added for unflattening. #34 
* Some default file names are changes #34 

The README has been updated to reflect these changes.