### PR TITLE
[#111] Removed WITH_CELLS option and deleted unused functions

### DIFF
--- a/docs/developerguide.rst
+++ b/docs/developerguide.rst
@@ -96,15 +96,6 @@ behaviour:
    Decimal('1.3000000000000000444089209850062616169452667236328125')
 
 
-Clean up of code
-----------------
-
-Now that we are happy with the approach the code takes internally, we can
-remove functions that we no longer need. In particular we can remove code
-branches where `WITH_CELLS` is `False` because we are happy with the cell
-source map implementation.
-
-
 Stdin support
 -------------
 

--- a/examples/cafe/relationship-merge-multiple/expected_stderr.json
+++ b/examples/cafe/relationship-merge-multiple/expected_stderr.json
@@ -1,4 +1,4 @@
-.../flattentool/input.py:114: UserWarning: Conflict when merging field "name" for id "CAFE-HEALTH" in sheet b: "Healthy Cafe" != "Incorrect value". If you were not expecting merging you may have a duplicate ID.
+... UserWarning: Conflict when merging field "name" for id "CAFE-HEALTH" in sheet b: "Healthy Cafe" != "Incorrect value". If you were not expecting merging you may have a duplicate ID.
   key, id_info, debug_info.get('sheet_name'), base_value, value))
-.../flattentool/input.py:114: UserWarning: Conflict when merging field "number_of_tables" for id "CAFE-HEALTH" in sheet d: "3" != "4". If you were not expecting merging you may have a duplicate ID.
+... UserWarning: Conflict when merging field "number_of_tables" for id "CAFE-HEALTH" in sheet d: "3" != "4". If you were not expecting merging you may have a duplicate ID.
   key, id_info, debug_info.get('sheet_name'), base_value, value))

--- a/examples/cafe/relationship-merge-single/expected_stderr.json
+++ b/examples/cafe/relationship-merge-single/expected_stderr.json
@@ -1,4 +1,4 @@
-.../flattentool/input.py:114: UserWarning: Conflict when merging field "name" for id "CAFE-HEALTH" in sheet data: "Healthy Cafe" != "Vegetarian Cafe". If you were not expecting merging you may have a duplicate ID.
+... UserWarning: Conflict when merging field "name" for id "CAFE-HEALTH" in sheet data: "Healthy Cafe" != "Vegetarian Cafe". If you were not expecting merging you may have a duplicate ID.
   key, id_info, debug_info.get('sheet_name'), base_value, value))
-.../flattentool/input.py:114: UserWarning: Conflict when merging field "number_of_tables" for id "CAFE-HEALTH" in sheet data: "3" != "4". If you were not expecting merging you may have a duplicate ID.
+... UserWarning: Conflict when merging field "number_of_tables" for id "CAFE-HEALTH" in sheet data: "3" != "4". If you were not expecting merging you may have a duplicate ID.
   key, id_info, debug_info.get('sheet_name'), base_value, value))

--- a/flattentool/__init__.py
+++ b/flattentool/__init__.py
@@ -2,7 +2,7 @@ from flattentool.schema import SchemaParser
 from flattentool.json_input import JSONParser
 from flattentool.output import FORMATS as OUTPUT_FORMATS
 from flattentool.output import FORMATS_SUFFIX
-from flattentool.input import FORMATS as INPUT_FORMATS, WITH_CELLS
+from flattentool.input import FORMATS as INPUT_FORMATS
 import json
 import codecs
 from decimal import Decimal
@@ -134,26 +134,16 @@ def unflatten(input_name, base_json=None, input_format=None, output_name=None,
             base = json.load(fp, object_pairs_hook=OrderedDict)
     else:
         base = OrderedDict()
-    if WITH_CELLS:
-        result, cell_source_map_data, heading_source_map_data = spreadsheet_input.fancy_unflatten()
-        base[root_list_path] = list(result)
-        if output_name is None:
-            print(json.dumps(base, indent=4, default=decimal_default, ensure_ascii=False))
-        else:
-            with codecs.open(output_name, 'w', encoding='utf-8') as fp:
-                json.dump(base, fp, indent=4, default=decimal_default, ensure_ascii=False)
-        if cell_source_map:
-            with codecs.open(cell_source_map, 'w', encoding='utf-8') as fp:
-                json.dump(cell_source_map_data, fp, indent=4, default=decimal_default, ensure_ascii=False)
-        if heading_source_map:
-            with codecs.open(heading_source_map, 'w', encoding='utf-8') as fp:
-                json.dump(heading_source_map_data, fp, indent=4, default=decimal_default, ensure_ascii=False)
+    result, cell_source_map_data, heading_source_map_data = spreadsheet_input.fancy_unflatten()
+    base[root_list_path] = list(result)
+    if output_name is None:
+        print(json.dumps(base, indent=4, default=decimal_default, ensure_ascii=False))
     else:
-        result = spreadsheet_input.unflatten()
-        base[root_list_path] = list(result)
-        if output_name is None:
-            print(json.dumps(base, indent=4, default=decimal_default, ensure_ascii=False))
-        else:
-            with codecs.open(output_name, 'w', encoding='utf-8') as fp:
-                json.dump(base, fp, indent=4, default=decimal_default, ensure_ascii=False)
-
+        with codecs.open(output_name, 'w', encoding='utf-8') as fp:
+            json.dump(base, fp, indent=4, default=decimal_default, ensure_ascii=False)
+    if cell_source_map:
+        with codecs.open(cell_source_map, 'w', encoding='utf-8') as fp:
+            json.dump(cell_source_map_data, fp, indent=4, default=decimal_default, ensure_ascii=False)
+    if heading_source_map:
+        with codecs.open(heading_source_map, 'w', encoding='utf-8') as fp:
+            json.dump(heading_source_map_data, fp, indent=4, default=decimal_default, ensure_ascii=False)

--- a/flattentool/tests/test_docs.py
+++ b/flattentool/tests/test_docs.py
@@ -51,13 +51,12 @@ def test_cafe_examples_in_docs():
                             expected_stderr_lines = text_type(data, 'utf8').split('\n')
                             for line in expected_stderr_lines:
                                 if line:
-                                    if line.startswith('.../'):
-                                        line = text_type(os.getcwd()) + line[3:]
                                     expected_stderr += (line + '\n').encode('utf8')
                                 else:
                                      expected_stderr += b'\n'
-                    assert _strip(actual_stdout) == _strip(expected_stdout), cmds
-                    assert _strip(actual_stderr) == _strip(expected_stderr), cmds
+                    assert _simplify_warnings(_strip(actual_stderr)) == _simplify_warnings(_strip(expected_stderr)), "Different stderr: {}".format(cmds)
+                    assert _strip(actual_stdout) == _strip(expected_stdout), "Different stdout: {}".format(cmds)
+                    assert _simplify_warnings(_strip(actual_stderr)) == _simplify_warnings(_strip(expected_stderr)), "Different stderr: {}".format(cmds)
                     tests_passed += 1
     # Check that the number of tests were run that we expected
     if sys.version_info[:2] < (3,4):
@@ -65,6 +64,13 @@ def test_cafe_examples_in_docs():
     else:
         assert tests_passed == 29
 
+def _simplify_warnings(lines):
+    return '\n'.join([_simplify_line(line) for line in lines.split('\n')])
+
+def _simplify_line(line):
+    if 'UserWarning: ' in line:
+        return line[line.find('UserWarning: '):]
+    return line
 
 # Older versions of Python have an extra whitespace at the end compared to newer ones
 # https://bugs.python.org/issue16333

--- a/flattentool/tests/test_headings.py
+++ b/flattentool/tests/test_headings.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from flattentool.input import SpreadsheetInput, WITH_CELLS
+from flattentool.input import SpreadsheetInput
 from flattentool.schema import SchemaParser
 from jsonref import JsonRef
 import pytest
@@ -72,8 +72,6 @@ class HeadingListInput(SpreadsheetInput):
 
 
 def run(sheets, schema=None, source_maps=False):
-    if not WITH_CELLS:
-        source_maps = False
     input_headings = OrderedDict()
     input_sheets = OrderedDict()
     for sheet in sheets:

--- a/flattentool/tests/test_init.py
+++ b/flattentool/tests/test_init.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from flattentool import decimal_default, unflatten, WITH_CELLS
+from flattentool import decimal_default, unflatten
 from decimal import Decimal
 import json
 import sys
@@ -47,832 +47,824 @@ def test_unflatten(tmpdir):
         'ocid,id,sub/0/id,sub/0/subsub/0/testG\n'
         '1,2,S1,23\n'
     )
-    if WITH_CELLS:
-        unflatten(
-            input_dir.strpath,
-            input_format='csv',
-            output_name=tmpdir.join('release.json').strpath,
-            main_sheet_name='main',
-            cell_source_map=tmpdir.join('cell_source_map.json').strpath,
-            heading_source_map=tmpdir.join('heading_source_map.json').strpath)
-    else:
-        unflatten(
-            input_dir.strpath,
-            input_format='csv',
-            output_name=tmpdir.join('release.json').strpath,
-            main_sheet_name='main')
-    if WITH_CELLS:
-        # Note, "main/0/testA": comes after "main/0/test" because 'testA' > 'testA'
-        # Note also that all the row entries come after the cell ones
-        expected = '''{
-            "main/0/id": [
-                [
-                    "main",
-                    "B",
-                    2,
-                    "id"
-                ],
-                [
-                    "subsheet",
-                    "B",
-                    2,
-                    "id"
-                ],
-                [
-                    "subsheet",
-                    "B",
-                    4,
-                    "id"
-                ],
-                [
-                    "subsheet_test",
-                    "B",
-                    2,
-                    "id"
-                ],
-                [
-                    "subsubsheet",
-                    "B",
-                    2,
-                    "id"
-                ]
+    unflatten(
+        input_dir.strpath,
+        input_format='csv',
+        output_name=tmpdir.join('release.json').strpath,
+        main_sheet_name='main',
+        cell_source_map=tmpdir.join('cell_source_map.json').strpath,
+        heading_source_map=tmpdir.join('heading_source_map.json').strpath)
+    # Note, "main/0/testA": comes after "main/0/test" because 'testA' > 'testA'
+    # Note also that all the row entries come after the cell ones
+    expected = '''{
+        "main/0/id": [
+            [
+                "main",
+                "B",
+                2,
+                "id"
             ],
-            "main/0/ocid": [
-                [
-                    "main",
-                    "A",
-                    2,
-                    "ocid"
-                ],
-                [
-                    "subsheet",
-                    "A",
-                    2,
-                    "ocid"
-                ],
-                [
-                    "subsheet",
-                    "A",
-                    4,
-                    "ocid"
-                ],
-                [
-                    "subsheet_test",
-                    "A",
-                    2,
-                    "ocid"
-                ],
-                [
-                    "subsubsheet",
-                    "A",
-                    2,
-                    "ocid"
-                ]
+            [
+                "subsheet",
+                "B",
+                2,
+                "id"
             ],
-            "main/0/sub/0/id": [
-                [
-                    "subsheet",
-                    "C",
-                    2,
-                    "sub/0/id"
-                ],
-                [
-                    "subsubsheet",
-                    "C",
-                    2,
-                    "sub/0/id"
-                ]
+            [
+                "subsheet",
+                "B",
+                4,
+                "id"
             ],
-            "main/0/sub/0/subsub/0/testG": [
-                [
-                    "subsubsheet",
-                    "D",
-                    2,
-                    "sub/0/subsub/0/testG"
-                ]
+            [
+                "subsheet_test",
+                "B",
+                2,
+                "id"
             ],
-            "main/0/sub/0/test2/E": [
-                [
-                    "subsheet",
-                    "E",
-                    2,
-                    "sub/0/test2/E"
-                ]
-            ],
-            "main/0/sub/0/test2/F": [
-                [
-                    "subsheet",
-                    "F",
-                    2,
-                    "sub/0/test2/F"
-                ]
-            ],
-            "main/0/sub/0/testD": [
-                [
-                    "subsheet",
-                    "D",
-                    2,
-                    "sub/0/testD"
-                ]
-            ],
-            "main/0/sub/1/id": [
-                [
-                    "subsheet",
-                    "C",
-                    4,
-                    "sub/0/id"
-                ]
-            ],
-            "main/0/sub/1/test2/E": [
-                [
-                    "subsheet",
-                    "E",
-                    4,
-                    "sub/0/test2/E"
-                ]
-            ],
-            "main/0/sub/1/test2/F": [
-                [
-                    "subsheet",
-                    "F",
-                    4,
-                    "sub/0/test2/F"
-                ]
-            ],
-            "main/0/sub/1/testD": [
-                [
-                    "subsheet",
-                    "D",
-                    4,
-                    "sub/0/testD"
-                ]
-            ],
-            "main/0/test/C": [
-                [
-                    "main",
-                    "E",
-                    2,
-                    "test/C"
-                ]
-            ],
-            "main/0/test/id": [
-                [
-                    "main",
-                    "D",
-                    2,
-                    "test/id"
-                ],
-                [
-                    "subsheet_test",
-                    "C",
-                    2,
-                    "test/id"
-                ]
-            ],
-            "main/0/test/subsheet/0/id": [
-                [
-                    "subsheet_test",
-                    "D",
-                    2,
-                    "test/subsheet/0/id"
-                ]
-            ],
-            "main/0/test/subsheet/0/test2/E": [
-                [
-                    "subsheet_test",
-                    "F",
-                    2,
-                    "test/subsheet/0/test2/E"
-                ]
-            ],
-            "main/0/test/subsheet/0/test2/F": [
-                [
-                    "subsheet_test",
-                    "G",
-                    2,
-                    "test/subsheet/0/test2/F"
-                ]
-            ],
-            "main/0/test/subsheet/0/testD": [
-                [
-                    "subsheet_test",
-                    "E",
-                    2,
-                    "test/subsheet/0/testD"
-                ]
-            ],
-            "main/0/testA": [
-                [
-                    "main",
-                    "C",
-                    2,
-                    "testA"
-                ]
-            ],
-            "main/1/id": [
-                [
-                    "main",
-                    "B",
-                    3,
-                    "id"
-                ],
-                [
-                    "subsheet",
-                    "B",
-                    3,
-                    "id"
-                ]
-            ],
-            "main/1/ocid": [
-                [
-                    "main",
-                    "A",
-                    3,
-                    "ocid"
-                ],
-                [
-                    "subsheet",
-                    "A",
-                    3,
-                    "ocid"
-                ]
-            ],
-            "main/1/sub/0/id": [
-                [
-                    "subsheet",
-                    "C",
-                    3,
-                    "sub/0/id"
-                ]
-            ],
-            "main/1/sub/0/test2/E": [
-                [
-                    "subsheet",
-                    "E",
-                    3,
-                    "sub/0/test2/E"
-                ]
-            ],
-            "main/1/sub/0/test2/F": [
-                [
-                    "subsheet",
-                    "F",
-                    3,
-                    "sub/0/test2/F"
-                ]
-            ],
-            "main/1/sub/0/testD": [
-                [
-                    "subsheet",
-                    "D",
-                    3,
-                    "sub/0/testD"
-                ]
-            ],
-            "main/1/test/C": [
-                [
-                    "main",
-                    "E",
-                    3,
-                    "test/C"
-                ]
-            ],
-            "main/1/test/id": [
-                [
-                    "main",
-                    "D",
-                    3,
-                    "test/id"
-                ]
-            ],
-            "main/1/testA": [
-                [
-                    "main",
-                    "C",
-                    3,
-                    "testA"
-                ]
-            ],
-            "main/2/id": [
-                [
-                    "main",
-                    "B",
-                    4,
-                    "id"
-                ],
-                [
-                    "subsheet",
-                    "B",
-                    5,
-                    "id"
-                ]
-            ],
-            "main/2/ocid": [
-                [
-                    "main",
-                    "A",
-                    4,
-                    "ocid"
-                ],
-                [
-                    "subsheet",
-                    "A",
-                    5,
-                    "ocid"
-                ]
-            ],
-            "main/2/sub/0/id": [
-                [
-                    "subsheet",
-                    "C",
-                    5,
-                    "sub/0/id"
-                ]
-            ],
-            "main/2/sub/0/test2/E": [
-                [
-                    "subsheet",
-                    "E",
-                    5,
-                    "sub/0/test2/E"
-                ]
-            ],
-            "main/2/sub/0/test2/F": [
-                [
-                    "subsheet",
-                    "F",
-                    5,
-                    "sub/0/test2/F"
-                ]
-            ],
-            "main/2/sub/0/testD": [
-                [
-                    "subsheet",
-                    "D",
-                    5,
-                    "sub/0/testD"
-                ]
-            ],
-            "main/2/test/C": [
-                [
-                    "main",
-                    "E",
-                    4,
-                    "test/C"
-                ]
-            ],
-            "main/2/test/id": [
-                [
-                    "main",
-                    "D",
-                    4,
-                    "test/id"
-                ]
-            ],
-            "main/2/testA": [
-                [
-                    "main",
-                    "C",
-                    4,
-                    "testA"
-                ]
-            ],
-            "main/3/id": [
-                [
-                    "main",
-                    "B",
-                    5,
-                    "id"
-                ]
-            ],
-            "main/3/ocid": [
-                [
-                    "main",
-                    "A",
-                    5,
-                    "ocid"
-                ]
-            ],
-            "main/3/test/C": [
-                [
-                    "main",
-                    "E",
-                    5,
-                    "test/C"
-                ]
-            ],
-            "main/3/test/id": [
-                [
-                    "main",
-                    "D",
-                    5,
-                    "test/id"
-                ]
-            ],
-            "main/3/testA": [
-                [
-                    "main",
-                    "C",
-                    5,
-                    "testA"
-                ]
-            ],
-            "main/0": [
-                [
-                    "main",
-                    2
-                ],
-                [
-                    "subsheet",
-                    2
-                ],
-                [
-                    "subsheet",
-                    4
-                ],
-                [
-                    "subsheet_test",
-                    2
-                ],
-                [
-                    "subsubsheet",
-                    2
-                ]
-            ],
-            "main/0/sub/0": [
-                [
-                    "subsheet",
-                    2
-                ],
-                [
-                    "subsubsheet",
-                    2
-                ]
-            ],
-            "main/0/sub/0/subsub/0": [
-                [
-                    "subsubsheet",
-                    2
-                ]
-            ],
-            "main/0/sub/0/test2": [
-                [
-                    "subsheet",
-                    2
-                ]
-            ],
-            "main/0/sub/1": [
-                [
-                    "subsheet",
-                    4
-                ]
-            ],
-            "main/0/sub/1/test2": [
-                [
-                    "subsheet",
-                    4
-                ]
-            ],
-            "main/0/test": [
-                [
-                    "main",
-                    2
-                ],
-                [
-                    "subsheet_test",
-                    2
-                ]
-            ],
-            "main/0/test/subsheet/0": [
-                [
-                    "subsheet_test",
-                    2
-                ]
-            ],
-            "main/0/test/subsheet/0/test2": [
-                [
-                    "subsheet_test",
-                    2
-                ]
-            ],
-            "main/1": [
-                [
-                    "main",
-                    3
-                ],
-                [
-                    "subsheet",
-                    3
-                ]
-            ],
-            "main/1/sub/0": [
-                [
-                    "subsheet",
-                    3
-                ]
-            ],
-            "main/1/sub/0/test2": [
-                [
-                    "subsheet",
-                    3
-                ]
-            ],
-            "main/1/test": [
-                [
-                    "main",
-                    3
-                ]
-            ],
-            "main/2": [
-                [
-                    "main",
-                    4
-                ],
-                [
-                    "subsheet",
-                    5
-                ]
-            ],
-            "main/2/sub/0": [
-                [
-                    "subsheet",
-                    5
-                ]
-            ],
-            "main/2/sub/0/test2": [
-                [
-                    "subsheet",
-                    5
-                ]
-            ],
-            "main/2/test": [
-                [
-                    "main",
-                    4
-                ]
-            ],
-            "main/3": [
-                [
-                    "main",
-                    5
-                ]
-            ],
-            "main/3/test": [
-                [
-                    "main",
-                    5
-                ]
+            [
+                "subsubsheet",
+                "B",
+                2,
+                "id"
             ]
-        }'''
-        assert lines_strip_whitespace(tmpdir.join('cell_source_map.json').read()) == lines_strip_whitespace(expected)
-        data = json.loads(expected)
-        cells = []
-        rows = {}
-        for key in data:
-            cell_list = data[key]
-            for cell in cell_list:
-                if len(cell) == 2:
-                    # This is a row
-                    row_str = '{}:{}'.format(cell[0], cell[1])
-                    if row_str not in rows:
-                        rows[row_str] = 1
-                    else:
-                        rows[row_str] += 1
+        ],
+        "main/0/ocid": [
+            [
+                "main",
+                "A",
+                2,
+                "ocid"
+            ],
+            [
+                "subsheet",
+                "A",
+                2,
+                "ocid"
+            ],
+            [
+                "subsheet",
+                "A",
+                4,
+                "ocid"
+            ],
+            [
+                "subsheet_test",
+                "A",
+                2,
+                "ocid"
+            ],
+            [
+                "subsubsheet",
+                "A",
+                2,
+                "ocid"
+            ]
+        ],
+        "main/0/sub/0/id": [
+            [
+                "subsheet",
+                "C",
+                2,
+                "sub/0/id"
+            ],
+            [
+                "subsubsheet",
+                "C",
+                2,
+                "sub/0/id"
+            ]
+        ],
+        "main/0/sub/0/subsub/0/testG": [
+            [
+                "subsubsheet",
+                "D",
+                2,
+                "sub/0/subsub/0/testG"
+            ]
+        ],
+        "main/0/sub/0/test2/E": [
+            [
+                "subsheet",
+                "E",
+                2,
+                "sub/0/test2/E"
+            ]
+        ],
+        "main/0/sub/0/test2/F": [
+            [
+                "subsheet",
+                "F",
+                2,
+                "sub/0/test2/F"
+            ]
+        ],
+        "main/0/sub/0/testD": [
+            [
+                "subsheet",
+                "D",
+                2,
+                "sub/0/testD"
+            ]
+        ],
+        "main/0/sub/1/id": [
+            [
+                "subsheet",
+                "C",
+                4,
+                "sub/0/id"
+            ]
+        ],
+        "main/0/sub/1/test2/E": [
+            [
+                "subsheet",
+                "E",
+                4,
+                "sub/0/test2/E"
+            ]
+        ],
+        "main/0/sub/1/test2/F": [
+            [
+                "subsheet",
+                "F",
+                4,
+                "sub/0/test2/F"
+            ]
+        ],
+        "main/0/sub/1/testD": [
+            [
+                "subsheet",
+                "D",
+                4,
+                "sub/0/testD"
+            ]
+        ],
+        "main/0/test/C": [
+            [
+                "main",
+                "E",
+                2,
+                "test/C"
+            ]
+        ],
+        "main/0/test/id": [
+            [
+                "main",
+                "D",
+                2,
+                "test/id"
+            ],
+            [
+                "subsheet_test",
+                "C",
+                2,
+                "test/id"
+            ]
+        ],
+        "main/0/test/subsheet/0/id": [
+            [
+                "subsheet_test",
+                "D",
+                2,
+                "test/subsheet/0/id"
+            ]
+        ],
+        "main/0/test/subsheet/0/test2/E": [
+            [
+                "subsheet_test",
+                "F",
+                2,
+                "test/subsheet/0/test2/E"
+            ]
+        ],
+        "main/0/test/subsheet/0/test2/F": [
+            [
+                "subsheet_test",
+                "G",
+                2,
+                "test/subsheet/0/test2/F"
+            ]
+        ],
+        "main/0/test/subsheet/0/testD": [
+            [
+                "subsheet_test",
+                "E",
+                2,
+                "test/subsheet/0/testD"
+            ]
+        ],
+        "main/0/testA": [
+            [
+                "main",
+                "C",
+                2,
+                "testA"
+            ]
+        ],
+        "main/1/id": [
+            [
+                "main",
+                "B",
+                3,
+                "id"
+            ],
+            [
+                "subsheet",
+                "B",
+                3,
+                "id"
+            ]
+        ],
+        "main/1/ocid": [
+            [
+                "main",
+                "A",
+                3,
+                "ocid"
+            ],
+            [
+                "subsheet",
+                "A",
+                3,
+                "ocid"
+            ]
+        ],
+        "main/1/sub/0/id": [
+            [
+                "subsheet",
+                "C",
+                3,
+                "sub/0/id"
+            ]
+        ],
+        "main/1/sub/0/test2/E": [
+            [
+                "subsheet",
+                "E",
+                3,
+                "sub/0/test2/E"
+            ]
+        ],
+        "main/1/sub/0/test2/F": [
+            [
+                "subsheet",
+                "F",
+                3,
+                "sub/0/test2/F"
+            ]
+        ],
+        "main/1/sub/0/testD": [
+            [
+                "subsheet",
+                "D",
+                3,
+                "sub/0/testD"
+            ]
+        ],
+        "main/1/test/C": [
+            [
+                "main",
+                "E",
+                3,
+                "test/C"
+            ]
+        ],
+        "main/1/test/id": [
+            [
+                "main",
+                "D",
+                3,
+                "test/id"
+            ]
+        ],
+        "main/1/testA": [
+            [
+                "main",
+                "C",
+                3,
+                "testA"
+            ]
+        ],
+        "main/2/id": [
+            [
+                "main",
+                "B",
+                4,
+                "id"
+            ],
+            [
+                "subsheet",
+                "B",
+                5,
+                "id"
+            ]
+        ],
+        "main/2/ocid": [
+            [
+                "main",
+                "A",
+                4,
+                "ocid"
+            ],
+            [
+                "subsheet",
+                "A",
+                5,
+                "ocid"
+            ]
+        ],
+        "main/2/sub/0/id": [
+            [
+                "subsheet",
+                "C",
+                5,
+                "sub/0/id"
+            ]
+        ],
+        "main/2/sub/0/test2/E": [
+            [
+                "subsheet",
+                "E",
+                5,
+                "sub/0/test2/E"
+            ]
+        ],
+        "main/2/sub/0/test2/F": [
+            [
+                "subsheet",
+                "F",
+                5,
+                "sub/0/test2/F"
+            ]
+        ],
+        "main/2/sub/0/testD": [
+            [
+                "subsheet",
+                "D",
+                5,
+                "sub/0/testD"
+            ]
+        ],
+        "main/2/test/C": [
+            [
+                "main",
+                "E",
+                4,
+                "test/C"
+            ]
+        ],
+        "main/2/test/id": [
+            [
+                "main",
+                "D",
+                4,
+                "test/id"
+            ]
+        ],
+        "main/2/testA": [
+            [
+                "main",
+                "C",
+                4,
+                "testA"
+            ]
+        ],
+        "main/3/id": [
+            [
+                "main",
+                "B",
+                5,
+                "id"
+            ]
+        ],
+        "main/3/ocid": [
+            [
+                "main",
+                "A",
+                5,
+                "ocid"
+            ]
+        ],
+        "main/3/test/C": [
+            [
+                "main",
+                "E",
+                5,
+                "test/C"
+            ]
+        ],
+        "main/3/test/id": [
+            [
+                "main",
+                "D",
+                5,
+                "test/id"
+            ]
+        ],
+        "main/3/testA": [
+            [
+                "main",
+                "C",
+                5,
+                "testA"
+            ]
+        ],
+        "main/0": [
+            [
+                "main",
+                2
+            ],
+            [
+                "subsheet",
+                2
+            ],
+            [
+                "subsheet",
+                4
+            ],
+            [
+                "subsheet_test",
+                2
+            ],
+            [
+                "subsubsheet",
+                2
+            ]
+        ],
+        "main/0/sub/0": [
+            [
+                "subsheet",
+                2
+            ],
+            [
+                "subsubsheet",
+                2
+            ]
+        ],
+        "main/0/sub/0/subsub/0": [
+            [
+                "subsubsheet",
+                2
+            ]
+        ],
+        "main/0/sub/0/test2": [
+            [
+                "subsheet",
+                2
+            ]
+        ],
+        "main/0/sub/1": [
+            [
+                "subsheet",
+                4
+            ]
+        ],
+        "main/0/sub/1/test2": [
+            [
+                "subsheet",
+                4
+            ]
+        ],
+        "main/0/test": [
+            [
+                "main",
+                2
+            ],
+            [
+                "subsheet_test",
+                2
+            ]
+        ],
+        "main/0/test/subsheet/0": [
+            [
+                "subsheet_test",
+                2
+            ]
+        ],
+        "main/0/test/subsheet/0/test2": [
+            [
+                "subsheet_test",
+                2
+            ]
+        ],
+        "main/1": [
+            [
+                "main",
+                3
+            ],
+            [
+                "subsheet",
+                3
+            ]
+        ],
+        "main/1/sub/0": [
+            [
+                "subsheet",
+                3
+            ]
+        ],
+        "main/1/sub/0/test2": [
+            [
+                "subsheet",
+                3
+            ]
+        ],
+        "main/1/test": [
+            [
+                "main",
+                3
+            ]
+        ],
+        "main/2": [
+            [
+                "main",
+                4
+            ],
+            [
+                "subsheet",
+                5
+            ]
+        ],
+        "main/2/sub/0": [
+            [
+                "subsheet",
+                5
+            ]
+        ],
+        "main/2/sub/0/test2": [
+            [
+                "subsheet",
+                5
+            ]
+        ],
+        "main/2/test": [
+            [
+                "main",
+                4
+            ]
+        ],
+        "main/3": [
+            [
+                "main",
+                5
+            ]
+        ],
+        "main/3/test": [
+            [
+                "main",
+                5
+            ]
+        ]
+    }'''
+    assert lines_strip_whitespace(tmpdir.join('cell_source_map.json').read()) == lines_strip_whitespace(expected)
+    data = json.loads(expected)
+    cells = []
+    rows = {}
+    for key in data:
+        cell_list = data[key]
+        for cell in cell_list:
+            if len(cell) == 2:
+                # This is a row
+                row_str = '{}:{}'.format(cell[0], cell[1])
+                if row_str not in rows:
+                    rows[row_str] = 1
                 else:
-                    # This is a cell
-                    cell_str = '{}:{}{}'.format(cell[0], cell[1], cell[2])
-                    assert cell_str not in cells
-                    cells.append(cell_str)
-        cells.sort()
-        # Make sure every cell in the original appeared in the cell source map exactly once
-        assert cells == [
-            'main:A2',
-            'main:A3',
-            'main:A4',
-            'main:A5',
-            'main:B2',
-            'main:B3',
-            'main:B4',
-            'main:B5',
-            'main:C2',
-            'main:C3',
-            'main:C4',
-            'main:C5',
-            'main:D2',
-            'main:D3',
-            'main:D4',
-            'main:D5',
-            'main:E2',
-            'main:E3',
-            'main:E4',
-            'main:E5',
-            'subsheet:A2',
-            'subsheet:A3',
-            'subsheet:A4',
-            'subsheet:A5',
-            'subsheet:B2',
-            'subsheet:B3',
-            'subsheet:B4',
-            'subsheet:B5',
-            'subsheet:C2',
-            'subsheet:C3',
-            'subsheet:C4',
-            'subsheet:C5',
-            'subsheet:D2',
-            'subsheet:D3',
-            'subsheet:D4',
-            'subsheet:D5',
-            'subsheet:E2',
-            'subsheet:E3',
-            'subsheet:E4',
-            'subsheet:E5',
-            'subsheet:F2',
-            'subsheet:F3',
-            'subsheet:F4',
-            'subsheet:F5',
-            'subsheet_test:A2',
-            'subsheet_test:B2',
-            'subsheet_test:C2',
-            'subsheet_test:D2',
-            'subsheet_test:E2',
-            'subsheet_test:F2',
-            'subsheet_test:G2',
-            'subsubsheet:A2',
-            'subsubsheet:B2',
-            'subsubsheet:C2',
-            'subsubsheet:D2'
-        ]
-        # Make sure every row in the original appeared the number of times a column in it resolves to a unique dictionary
-        assert rows == {
-            'main:2': 2,
-            'main:3': 2,
-            'main:4': 2,
-            'main:5': 2,
-            'subsheet:2': 3,
-            'subsheet:3': 3,
-            'subsheet:4': 3,
-            'subsheet:5': 3,
-            'subsheet_test:2': 4,
-            'subsubsheet:2': 3,
-        }
-        # TODO Check column names with a JSON schema
-        expected_headings = '''{
-            "main/id": [
-                [
-                    "main",
-                    "id"
-                ],
-                [
-                    "subsheet",
-                    "id"
-                ],
-                [
-                    "subsheet_test",
-                    "id"
-                ],
-                [
-                    "subsubsheet",
-                    "id"
-                ]
+                    rows[row_str] += 1
+            else:
+                # This is a cell
+                cell_str = '{}:{}{}'.format(cell[0], cell[1], cell[2])
+                assert cell_str not in cells
+                cells.append(cell_str)
+    cells.sort()
+    # Make sure every cell in the original appeared in the cell source map exactly once
+    assert cells == [
+        'main:A2',
+        'main:A3',
+        'main:A4',
+        'main:A5',
+        'main:B2',
+        'main:B3',
+        'main:B4',
+        'main:B5',
+        'main:C2',
+        'main:C3',
+        'main:C4',
+        'main:C5',
+        'main:D2',
+        'main:D3',
+        'main:D4',
+        'main:D5',
+        'main:E2',
+        'main:E3',
+        'main:E4',
+        'main:E5',
+        'subsheet:A2',
+        'subsheet:A3',
+        'subsheet:A4',
+        'subsheet:A5',
+        'subsheet:B2',
+        'subsheet:B3',
+        'subsheet:B4',
+        'subsheet:B5',
+        'subsheet:C2',
+        'subsheet:C3',
+        'subsheet:C4',
+        'subsheet:C5',
+        'subsheet:D2',
+        'subsheet:D3',
+        'subsheet:D4',
+        'subsheet:D5',
+        'subsheet:E2',
+        'subsheet:E3',
+        'subsheet:E4',
+        'subsheet:E5',
+        'subsheet:F2',
+        'subsheet:F3',
+        'subsheet:F4',
+        'subsheet:F5',
+        'subsheet_test:A2',
+        'subsheet_test:B2',
+        'subsheet_test:C2',
+        'subsheet_test:D2',
+        'subsheet_test:E2',
+        'subsheet_test:F2',
+        'subsheet_test:G2',
+        'subsubsheet:A2',
+        'subsubsheet:B2',
+        'subsubsheet:C2',
+        'subsubsheet:D2'
+    ]
+    # Make sure every row in the original appeared the number of times a column in it resolves to a unique dictionary
+    assert rows == {
+        'main:2': 2,
+        'main:3': 2,
+        'main:4': 2,
+        'main:5': 2,
+        'subsheet:2': 3,
+        'subsheet:3': 3,
+        'subsheet:4': 3,
+        'subsheet:5': 3,
+        'subsheet_test:2': 4,
+        'subsubsheet:2': 3,
+    }
+    # TODO Check column names with a JSON schema
+    expected_headings = '''{
+        "main/id": [
+            [
+                "main",
+                "id"
             ],
-            "main/ocid": [
-                [
-                    "main",
-                    "ocid"
-                ],
-                [
-                    "subsheet",
-                    "ocid"
-                ],
-                [
-                    "subsheet_test",
-                    "ocid"
-                ],
-                [
-                    "subsubsheet",
-                    "ocid"
-                ]
+            [
+                "subsheet",
+                "id"
             ],
-            "main/sub/id": [
-                [
-                    "subsheet",
-                    "sub/0/id"
-                ],
-                [
-                    "subsubsheet",
-                    "sub/0/id"
-                ]
+            [
+                "subsheet_test",
+                "id"
             ],
-            "main/sub/subsub/testG": [
-                [
-                    "subsubsheet",
-                    "sub/0/subsub/0/testG"
-                ]
-            ],
-            "main/sub/test2/E": [
-                [
-                    "subsheet",
-                    "sub/0/test2/E"
-                ]
-            ],
-            "main/sub/test2/F": [
-                [
-                    "subsheet",
-                    "sub/0/test2/F"
-                ]
-            ],
-            "main/sub/testD": [
-                [
-                    "subsheet",
-                    "sub/0/testD"
-                ]
-            ],
-            "main/test/C": [
-                [
-                    "main",
-                    "test/C"
-                ]
-            ],
-            "main/test/id": [
-                [
-                    "main",
-                    "test/id"
-                ],
-                [
-                    "subsheet_test",
-                    "test/id"
-                ]
-            ],
-            "main/test/subsheet/id": [
-                [
-                    "subsheet_test",
-                    "test/subsheet/0/id"
-                ]
-            ],
-            "main/test/subsheet/test2/E": [
-                [
-                    "subsheet_test",
-                    "test/subsheet/0/test2/E"
-                ]
-            ],
-            "main/test/subsheet/test2/F": [
-                [
-                    "subsheet_test",
-                    "test/subsheet/0/test2/F"
-                ]
-            ],
-            "main/test/subsheet/testD": [
-                [
-                    "subsheet_test",
-                    "test/subsheet/0/testD"
-                ]
-            ],
-            "main/testA": [
-                [
-                    "main",
-                    "testA"
-                ]
+            [
+                "subsubsheet",
+                "id"
             ]
-        }'''
-        assert lines_strip_whitespace(tmpdir.join('heading_source_map.json').read()) == lines_strip_whitespace(expected_headings)
-        heading_data = json.loads(expected_headings)
-        headings = []
-        for key in heading_data:
-            cell_list = heading_data[key]
-            for cell in cell_list:
-                assert len(cell) == 2
-                heading_str = '{}:{}'.format(cell[0], cell[1])
-                assert heading_str not in headings
-                headings.append(heading_str)
-        headings.sort()
-        # Make sure every heading in the original appeared in the heading source map exactly once
-        assert headings == [
-            'main:id',
-            'main:ocid',
-            'main:test/C',
-            'main:test/id',
-            'main:testA',
-
-            'subsheet:id',
-            'subsheet:ocid',
-            'subsheet:sub/0/id',
-            'subsheet:sub/0/test2/E',
-            'subsheet:sub/0/test2/F',
-            'subsheet:sub/0/testD',
-
-            'subsheet_test:id',
-            'subsheet_test:ocid',
-            'subsheet_test:test/id',
-            'subsheet_test:test/subsheet/0/id',
-            'subsheet_test:test/subsheet/0/test2/E',
-            'subsheet_test:test/subsheet/0/test2/F',
-            'subsheet_test:test/subsheet/0/testD',
-
-            'subsubsheet:id',
-            'subsubsheet:ocid',
-            'subsubsheet:sub/0/id',
-            'subsubsheet:sub/0/subsub/0/testG',
+        ],
+        "main/ocid": [
+            [
+                "main",
+                "ocid"
+            ],
+            [
+                "subsheet",
+                "ocid"
+            ],
+            [
+                "subsheet_test",
+                "ocid"
+            ],
+            [
+                "subsubsheet",
+                "ocid"
+            ]
+        ],
+        "main/sub/id": [
+            [
+                "subsheet",
+                "sub/0/id"
+            ],
+            [
+                "subsubsheet",
+                "sub/0/id"
+            ]
+        ],
+        "main/sub/subsub/testG": [
+            [
+                "subsubsheet",
+                "sub/0/subsub/0/testG"
+            ]
+        ],
+        "main/sub/test2/E": [
+            [
+                "subsheet",
+                "sub/0/test2/E"
+            ]
+        ],
+        "main/sub/test2/F": [
+            [
+                "subsheet",
+                "sub/0/test2/F"
+            ]
+        ],
+        "main/sub/testD": [
+            [
+                "subsheet",
+                "sub/0/testD"
+            ]
+        ],
+        "main/test/C": [
+            [
+                "main",
+                "test/C"
+            ]
+        ],
+        "main/test/id": [
+            [
+                "main",
+                "test/id"
+            ],
+            [
+                "subsheet_test",
+                "test/id"
+            ]
+        ],
+        "main/test/subsheet/id": [
+            [
+                "subsheet_test",
+                "test/subsheet/0/id"
+            ]
+        ],
+        "main/test/subsheet/test2/E": [
+            [
+                "subsheet_test",
+                "test/subsheet/0/test2/E"
+            ]
+        ],
+        "main/test/subsheet/test2/F": [
+            [
+                "subsheet_test",
+                "test/subsheet/0/test2/F"
+            ]
+        ],
+        "main/test/subsheet/testD": [
+            [
+                "subsheet_test",
+                "test/subsheet/0/testD"
+            ]
+        ],
+        "main/testA": [
+            [
+                "main",
+                "testA"
+            ]
         ]
+    }'''
+    assert lines_strip_whitespace(tmpdir.join('heading_source_map.json').read()) == lines_strip_whitespace(expected_headings)
+    heading_data = json.loads(expected_headings)
+    headings = []
+    for key in heading_data:
+        cell_list = heading_data[key]
+        for cell in cell_list:
+            assert len(cell) == 2
+            heading_str = '{}:{}'.format(cell[0], cell[1])
+            assert heading_str not in headings
+            headings.append(heading_str)
+    headings.sort()
+    # Make sure every heading in the original appeared in the heading source map exactly once
+    assert headings == [
+        'main:id',
+        'main:ocid',
+        'main:test/C',
+        'main:test/id',
+        'main:testA',
+
+        'subsheet:id',
+        'subsheet:ocid',
+        'subsheet:sub/0/id',
+        'subsheet:sub/0/test2/E',
+        'subsheet:sub/0/test2/F',
+        'subsheet:sub/0/testD',
+
+        'subsheet_test:id',
+        'subsheet_test:ocid',
+        'subsheet_test:test/id',
+        'subsheet_test:test/subsheet/0/id',
+        'subsheet_test:test/subsheet/0/test2/E',
+        'subsheet_test:test/subsheet/0/test2/F',
+        'subsheet_test:test/subsheet/0/testD',
+
+        'subsubsheet:id',
+        'subsubsheet:ocid',
+        'subsubsheet:sub/0/id',
+        'subsubsheet:sub/0/subsub/0/testG',
+    ]
     assert lines_strip_whitespace(tmpdir.join('release.json').read()) == lines_strip_whitespace('''{
     "main": [
         {

--- a/flattentool/tests/test_input.py
+++ b/flattentool/tests/test_input.py
@@ -4,8 +4,7 @@ Tests of functions in input.py
 Tests of SpreadsheetInput class and its children are in test_input_SpreadsheetInput*.py
 """
 from __future__ import unicode_literals
-from flattentool.input import unflatten_line, \
-    find_deepest_id_field, path_search
+from flattentool.input import path_search
 from decimal import Decimal
 from collections import OrderedDict
 import sys
@@ -13,14 +12,6 @@ import pytest
 import openpyxl
 import datetime
 from six import text_type
-
-
-def test_unflatten_line():
-    # Check flat fields remain flat
-    assert unflatten_line({'a': 1, 'b': 2}) == {'a': 1, 'b': 2}
-    assert unflatten_line({'a/b': 1, 'a/c': 2, 'd/e': 3}) == {'a': {'b': 1, 'c': 2}, 'd': {'e': 3}}
-    # Check more than two levels of nesting, and that multicharacter fields aren't broken
-    assert unflatten_line({'fieldA/b/c/d': 'value'}) == {'fieldA': {'b': {'c': {'d': 'value'}}}}
 
 
 def test_path_search():
@@ -47,9 +38,3 @@ def test_path_search():
         ['a1', 'c1'],
         id_fields={'a1/id': 'b1'},
         top=True) is goal_dict
-
-
-def test_find_deepest_id_field():
-    assert find_deepest_id_field(['a/b/id', 'a/b/c/id']) == 'a/b/c/id'
-    with pytest.raises(ValueError):
-        find_deepest_id_field(['a/b/id', 'c/id'])


### PR DESCRIPTION
I've also refactored `test_docs.py` a bit so that line numbers and file paths aren't checked in the tests - this means they won't fail just because the same warning is triggered from a slightly different line in the source file.

Leaving `path_search()` in place for the timebeing. 