### PR TITLE
Fix openpyxl dependency issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 import sys
 
-install_requires = ['jsonref', 'schema', 'openpyxl>=2', 'six', 'pytz']
+install_requires = ['jsonref', 'schema', 'openpyxl>=2,<2.4', 'six', 'pytz']
 
 if sys.version < '3':
     install_requires.append('unicodecsv')


### PR DESCRIPTION
Flatten-tool is not compatible with openpyxl 2.4.
There's no "_get_column_letter" in openpyxl.utils anymore.