### PR TITLE
Improve tests

### DIFF
--- a/flattentool/input.py
+++ b/flattentool/input.py
@@ -149,7 +149,7 @@ class SpreadsheetInput(object):
 
         """
         if self.parser:
-            title_lookup = title_lookup or self.parser.title_lookup
+            title_lookup = self.parser.title_lookup
         for d in dicts:
             if title_lookup:
                 yield OrderedDict([(title_lookup.lookup_header(k), v) for k,v in d.items()])

--- a/flattentool/input.py
+++ b/flattentool/input.py
@@ -98,6 +98,19 @@ def convert_type(type_string, value, timezone = pytz.timezone('UTC')):
         raise ValueError('Unrecognised type: "{}"'.format(type_string))
 
 
+def warnings_for_ignored_columns(v, extra_message):
+    if isinstance(v, Cell):
+        warn('Column {} has been ignored, {}'.format(v.cell_location[3], extra_message))
+    elif isinstance(v, dict):
+        for x in v.values():
+            warnings_for_ignored_columns(x, extra_message)
+    elif isinstance(v, TemporaryDict):
+        for x in v.to_list():
+            warnings_for_ignored_columns(x, extra_message)
+    else:
+        raise ValueError()
+
+
 def merge(base, mergee, debug_info=None):
     if not debug_info:
         debug_info = {}
@@ -108,6 +121,9 @@ def merge(base, mergee, debug_info=None):
             value = v
         if key in base:
             if isinstance(value, TemporaryDict):
+                if not isinstance(base[key], TemporaryDict):
+                    warnings_for_ignored_columns(v, 'because it treats {} as an array, but another column does not'.format(key))
+                    continue
                 for temporarydict_key, temporarydict_value in value.items():
                     if temporarydict_key in base[key]:
                         merge(base[key][temporarydict_key], temporarydict_value, debug_info)
@@ -116,9 +132,18 @@ def merge(base, mergee, debug_info=None):
                         base[key][temporarydict_key] = temporarydict_value
                 for temporarydict_value in  value.items_no_keyfield:
                     base[key].items_no_keyfield.append(temporarydict_value)
-            elif isinstance(value, dict) and isinstance(base[key], dict):
-                merge(base[key], value, debug_info)
+            elif isinstance(value, dict):
+                if isinstance(base[key], dict):
+                    merge(base[key], value, debug_info)
+                else:
+                    warnings_for_ignored_columns(v, 'because it treats {} as an object, but another column does not'.format(key))
             else:
+                if not isinstance(base[key], Cell):
+                    id_info = '{} "{}"'.format(debug_info.get('id_name'), debug_info.get(debug_info.get('id_name')))
+                    if debug_info.get('root_id'):
+                        id_info = '{} "{}", '.format(debug_info.get('root_id'), debug_info.get('root_id_or_none'))+id_info
+                    warnings_for_ignored_columns(v, 'because another column treats it as an array or object'.format(key))
+                    continue
                 base_value = base[key].cell_value
                 if base_value != value:
                     id_info = '{} "{}"'.format(debug_info.get('id_name'), debug_info.get(debug_info.get('id_name')))

--- a/flattentool/json_input.py
+++ b/flattentool/json_input.py
@@ -140,7 +140,12 @@ class JSONParser(object):
                     if self.rollup and parent_name == '': # Rollup only currently possible to main sheet
                         if len(value) == 1:
                             for k, v in value[0].items():
-                                if parent_name+key+'/0/'+k in self.schema_parser.main_sheet:
+                                if self.use_titles and parent_name+key+'/0/'+k in self.schema_parser.main_sheet.titles:
+                                    if type(v) in BASIC_TYPES:
+                                        flattened_dict[sheet_key_title(sheet, parent_name+key+'/0/'+k)] = v
+                                    else:
+                                        raise ValueError('Rolled up values must be basic types')
+                                elif not self.use_titles and parent_name+key+'/0/'+k in self.schema_parser.main_sheet:
                                     if type(v) in BASIC_TYPES:
                                         flattened_dict[sheet_key(sheet, parent_name+key+'/0/'+k)] = v
                                     else:

--- a/flattentool/json_input.py
+++ b/flattentool/json_input.py
@@ -23,23 +23,21 @@ class BadlyFormedJSONError(ValueError):
     pass
 
 
-def sheet_key_field(sheet, key, id_key=None):
+def sheet_key_field(sheet, key):
     if key not in sheet:
         sheet.append(key)
     return key
 
-def sheet_key_title(sheet, key, id_key=None):
+def sheet_key_title(sheet, key):
     """
     If the key has a corresponding title, return that. If doesn't, create it in the sheet and return it.
 
     """
-    if id_key: # call sheet_key_field instead
-        return sheet_key_field(sheet, key, id_key)
-    title_lookup = {v: k for k, v in sheet.titles.items()}
-    if key in title_lookup:
-        return title_lookup[key]
+    if key in sheet.titles:
+        return sheet.titles[key]
     else:
-        sheet.append(key)
+        if key not in sheet:
+            sheet.append(key)
         return key
 
 
@@ -111,13 +109,13 @@ class JSONParser(object):
         if top_level_of_sub_sheet:
             # Only add the IDs for the top level of object in an array
             for k, v in parent_id_fields.items():
-                flattened_dict[sheet_key(sheet, k, id_key=json_key)] = v
+                flattened_dict[sheet_key(sheet, k)] = v
 
         if self.root_id and self.root_id in json_dict:
-            parent_id_fields[self.root_id] = json_dict[self.root_id]
+            parent_id_fields[sheet_key(sheet, self.root_id)] = json_dict[self.root_id]
 
         if 'id' in json_dict:
-            parent_id_fields[parent_name+'id'] = json_dict['id']
+            parent_id_fields[sheet_key(sheet, parent_name+'id')] = json_dict['id']
 
 
         for key, value in json_dict.items():

--- a/flattentool/schema.py
+++ b/flattentool/schema.py
@@ -104,6 +104,7 @@ class SchemaParser(object):
                     warn('Field {} does not have a title, skipping.'.format(field))
                 else:
                     self.main_sheet.append(title)
+                    self.main_sheet.titles[field] = title
             else:
                 self.main_sheet.append(field)
 
@@ -174,16 +175,17 @@ class SchemaParser(object):
 
                         for field in id_fields:
                             sub_sheet.add_field(field, id_field=True)
+                            sub_sheet.titles[title_lookup.lookup_header(field)] = field
                         fields = self.parse_schema_dict(
                                 parent_path+property_name+'/0',
                                 property_schema_dict['items'],
                                 parent_id_fields=id_fields,
                                 title_lookup=title_lookup.get(title),
                                 parent_title=parent_title+title+':' if parent_title is not None and title else None)
-
                         rolledUp = set()
 
                         for field, child_title in fields:
+                            full_path = parent_path+property_name+'/0/'+field
                             if self.use_titles:
                                 if not child_title or parent_title is None:
                                     warn('Field {}{}/0/{} is missing a title, skipping.'.format(parent_path, property_name, field))
@@ -191,9 +193,11 @@ class SchemaParser(object):
                                     warn('Field {}{} does not have a title, skipping it and all its children.'.format(parent_path, property_name))
                                 else:
                                     # This code only works for arrays that are at 0 or 1 layer of nesting
-                                    sub_sheet.add_field(parent_title+title+':'+child_title)
+                                    full_title = parent_title+title+':'+child_title
+                                    sub_sheet.add_field(full_title)
+                                    sub_sheet.titles[full_path] = full_title
                             else:
-                                sub_sheet.add_field(parent_path+property_name+'/0/'+field)
+                                sub_sheet.add_field(full_path)
                             if self.rollup and 'rollUp' in property_schema_dict and field in property_schema_dict['rollUp']:
                                 rolledUp.add(field)
                                 yield property_name+'/0/'+field, (title+':'+child_title if title and child_title else None)

--- a/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
+++ b/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
@@ -54,7 +54,8 @@ testdata = [
                 'id': 2,
                 'testA': 3
         }],
-        []
+        [],
+        True
     ),
     (
         'Basic with zero',
@@ -68,7 +69,8 @@ testdata = [
                 'id': 2,
                 'testA': 0
         }],
-        []
+        [],
+        True
     ),
     (
         'Nested',
@@ -83,7 +85,8 @@ testdata = [
             'id': 2,
             'testO': {'testB': 3, 'testC': 4}
         }],
-        []
+        [],
+        True
     ),
     (
         'Unicode',
@@ -95,7 +98,8 @@ testdata = [
             'ROOT_ID': UNICODE_TEST_STRING,
             'testU': UNICODE_TEST_STRING
         }],
-        []
+        [],
+        True
     ),
     (
         'Single item array',
@@ -110,7 +114,8 @@ testdata = [
                 'id': 3, 'testB': 4
             }],
         }],
-        []
+        [],
+        False,
     ),
     (
         'Single item array without parent ID',
@@ -126,7 +131,8 @@ testdata = [
                 'testB': '3'
             }],
         }],
-        []
+        [],
+        False
     ),
     (
         'Empty',
@@ -140,7 +146,8 @@ testdata = [
             'testE': '',
         }],
         [],
-        []
+        [],
+        False
     ),
     (
         'Empty except for root id',
@@ -156,7 +163,8 @@ testdata = [
         [{
             'ROOT_ID': 1
         }],
-        []
+        [],
+        False
     ),
 # Previously this caused the error: TypeError: unorderable types: str() < int()
 # Now one of the columns is ignored
@@ -175,7 +183,8 @@ testdata = [
                 'a': 3,
             }
         }],
-        ['Column newtest/0/a has been ignored, because it treats newtest as an array, but another column does not.']
+        ['Column newtest/0/a has been ignored, because it treats newtest as an array, but another column does not.'],
+        False
     ),
 # Previously this caused the error: TypeError: unorderable types: str() < int()
 # Now one of the columns is ignored
@@ -194,7 +203,8 @@ testdata = [
                 {'a': 4}
             ]
         }],
-        ['Column newtest/a has been ignored, because it treats newtest as an object, but another column does not.']
+        ['Column newtest/a has been ignored, because it treats newtest as an object, but another column does not.'],
+        False
     ),
 # Previously this caused the error: 'Cell' object has no attribute 'get'
 # Now one of the columns is ignored
@@ -211,7 +221,8 @@ testdata = [
             'id': 2,
             'newtest': 3
         }],
-        ['Column newtest/0/a has been ignored, because it treats newtest as an array, but another column does not.']
+        ['Column newtest/0/a has been ignored, because it treats newtest as an array, but another column does not.'],
+        False
     ),
     (
         'str / object mixing',
@@ -226,7 +237,8 @@ testdata = [
             'id': 2,
             'newtest': 3
         }],
-        ['Column newtest/a has been ignored, because it treats newtest as an object, but another column does not.']
+        ['Column newtest/a has been ignored, because it treats newtest as an object, but another column does not.'],
+        False
     ),
     (
         'array / str mixing',
@@ -245,7 +257,8 @@ testdata = [
                 }]
             }
         }],
-        ['Column nest/newtest has been ignored, because another column treats it as an array or object']
+        ['Column nest/newtest has been ignored, because another column treats it as an array or object'],
+        False
     ),
     (
         'object / str mixing',
@@ -262,7 +275,8 @@ testdata = [
                 'a': 3
             }
         }],
-        ['Column newtest has been ignored, because another column treats it as an array or object']
+        ['Column newtest has been ignored, because another column treats it as an array or object'],
+        False
     ),
 # Previously this caused the error: KeyError('ocid',)
 # Now it works, but probably not as intended
@@ -278,7 +292,8 @@ testdata = [
             'id': 2,
             'testA': 3
         }],
-        []
+        [],
+        False
     ),
 # We should be able to handle numbers as column headings
     (
@@ -302,7 +317,8 @@ testdata = [
             'Column "2" has been ignored because it is a number.',
             'Column "3" has been ignored because it is a number.',
             'Column "4" has been ignored because it is a number.',
-        ]
+        ],
+        False
     )
 ]
 
@@ -456,7 +472,8 @@ testdata_titles = [
             'id': 2,
             'testA': 3
         }],
-        []
+        [],
+        True
     ),
     (
         'Nested',
@@ -471,7 +488,8 @@ testdata_titles = [
             'id': 2,
             'testB': {'testC': 3, 'testD': 4}
         }],
-        []
+        [],
+        True
     ),
     (
         'Nested titles should be converted individually',
@@ -486,7 +504,8 @@ testdata_titles = [
             'id': 2,
             'testB': {'testC': 3, 'Not in schema': 4}
         }],
-        []
+        [],
+        False
     ),
     (
         'Should be space and case invariant',
@@ -501,7 +520,8 @@ testdata_titles = [
             'id': 2,
             'testB': {'testC': 3, 'Not in schema': 4}
         }],
-        []
+        [],
+        False
     ),
     (
         'Unicode',
@@ -513,7 +533,8 @@ testdata_titles = [
             'ROOT_ID': UNICODE_TEST_STRING,
             'testU': UNICODE_TEST_STRING
         }],
-        []
+        [],
+        True
     ),
    (
         'Single item array',
@@ -530,7 +551,8 @@ testdata_titles = [
                 'id': '3', 'testB': '4'
             }],
         }],
-        []
+        [],
+        False
     ),
     (
         'Single item array without parent ID',
@@ -546,7 +568,8 @@ testdata_titles = [
                 'testB': '3'
             }],
         }],
-        []
+        [],
+        False
     ),
     (
         '''
@@ -567,7 +590,8 @@ testdata_titles = [
                 'testC': '4'
             }],
         }],
-        []
+        [],
+        False
     ),
     (
         'Single item array, titles should be converted individually',
@@ -585,7 +609,8 @@ testdata_titles = [
                 'Not in schema': 4
             }],
         }],
-        []
+        [],
+        False
     ),
     (
         'Multi item array, allow numbering',
@@ -616,7 +641,8 @@ testdata_titles = [
             }
             ]
         }],
-        []
+        [],
+        False
     ),
     (
         'Empty',
@@ -630,7 +656,8 @@ testdata_titles = [
             'E title': '',
         }],
         [],
-        []
+        [],
+        False
     ),
     (
         'Empty except for root id',
@@ -646,7 +673,8 @@ testdata_titles = [
         [{
             'ROOT_ID': 1
         }],
-        []
+        [],
+        False
     ),
     (
         'Test arrays of strings (1 item)',
@@ -660,7 +688,8 @@ testdata_titles = [
             'id': 2,
             'testSA': [ 'a' ],
         }],
-        []
+        [],
+        True
     ),
     (
         'Test arrays of strings (2 items)',
@@ -674,7 +703,8 @@ testdata_titles = [
             'id': 2,
             'testSA': [ 'a', 'b' ],
         }],
-        []
+        [],
+        True
     ),
     (
         'Test arrays of strings within an object array (1 item)',
@@ -690,7 +720,8 @@ testdata_titles = [
                 'testSA': [ 'a' ],
             }]
         }],
-        []
+        [],
+        False
     ),
     (
         'Test arrays of strings within an object array (2 items)',
@@ -706,7 +737,8 @@ testdata_titles = [
                 'testSA': [ 'a', 'b' ],
             }]
         }],
-        []
+        [],
+        False
     ),
 ]
 
@@ -723,8 +755,8 @@ ROOT_ID_PARAMS =     [
 @pytest.mark.parametrize('convert_titles', [True, False])
 @pytest.mark.parametrize('use_schema', [True, False])
 @pytest.mark.parametrize('root_id,root_id_kwargs', ROOT_ID_PARAMS)
-@pytest.mark.parametrize('comment,input_list,expected_output_list,warning_messages', testdata)
-def test_unflatten(convert_titles, use_schema, root_id, root_id_kwargs, input_list, expected_output_list, recwarn, comment, warning_messages):
+@pytest.mark.parametrize('comment,input_list,expected_output_list,warning_messages,reversible', testdata)
+def test_unflatten(convert_titles, use_schema, root_id, root_id_kwargs, input_list, expected_output_list, recwarn, comment, warning_messages, reversible):
     # Not sure why, but this seems to be necessary to have warnings picked up
     # on Python 2.7 and 3.3, but 3.4 and 3.5 are fine without it
     import warnings
@@ -765,12 +797,12 @@ def test_unflatten(convert_titles, use_schema, root_id, root_id_kwargs, input_li
 @pytest.mark.parametrize('root_id,root_id_kwargs', ROOT_ID_PARAMS)
 @pytest.mark.parametrize('comment,input_list,expected_output_list,warning_messages', testdata_pointer)
 def test_unflatten_pointer(convert_titles, root_id, root_id_kwargs, input_list, expected_output_list, recwarn, comment, warning_messages):
-    return test_unflatten(convert_titles=convert_titles, use_schema=True, root_id=root_id, root_id_kwargs=root_id_kwargs, input_list=input_list, expected_output_list=expected_output_list, recwarn=recwarn, comment=comment, warning_messages=warning_messages)
+    return test_unflatten(convert_titles=convert_titles, use_schema=True, root_id=root_id, root_id_kwargs=root_id_kwargs, input_list=input_list, expected_output_list=expected_output_list, recwarn=recwarn, comment=comment, warning_messages=warning_messages, reversible=False)
 
 
-@pytest.mark.parametrize('comment,input_list,expected_output_list,warning_messages', testdata_titles)
+@pytest.mark.parametrize('comment,input_list,expected_output_list,warning_messages,reversible', testdata_titles)
 @pytest.mark.parametrize('root_id,root_id_kwargs', ROOT_ID_PARAMS)
-def test_unflatten_titles(root_id, root_id_kwargs, input_list, expected_output_list, recwarn, comment, warning_messages):
+def test_unflatten_titles(root_id, root_id_kwargs, input_list, expected_output_list, recwarn, comment, warning_messages, reversible):
     """
     Essentially the same as test unflatten, except that convert_titles and
     use_schema are always true, as both of these are needed to convert titles
@@ -780,6 +812,6 @@ def test_unflatten_titles(root_id, root_id_kwargs, input_list, expected_output_l
         # Skip all tests with a root ID for now, as this is broken
         # https://github.com/OpenDataServices/flatten-tool/issues/84
         pytest.skip()
-    return test_unflatten(convert_titles=True, use_schema=True, root_id=root_id, root_id_kwargs=root_id_kwargs, input_list=input_list, expected_output_list=expected_output_list, recwarn=recwarn, comment=comment, warning_messages=warning_messages)
+    return test_unflatten(convert_titles=True, use_schema=True, root_id=root_id, root_id_kwargs=root_id_kwargs, input_list=input_list, expected_output_list=expected_output_list, recwarn=recwarn, comment=comment, warning_messages=warning_messages, reversible=reversible)
 
 

--- a/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
+++ b/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
@@ -278,6 +278,166 @@ testdata = [
         ['Column newtest has been ignored, because another column treats it as an array or object'],
         False
     ),
+    (
+        'Mismatch of object/array for field not in schema (multiline)',
+        [
+            OrderedDict([
+                ('ROOT_ID', 1),
+                ('id', 2),
+                ('nest/newtest/a', 3),
+            ]),
+            OrderedDict([
+                ('ROOT_ID', 1),
+                ('id', 2),
+                ('nest/newtest/0/a', 4),
+            ]),
+        ],
+        [{
+            'ROOT_ID': 1,
+            'id': 2,
+            'nest': {
+                'newtest': {
+                    'a': 3,
+                }
+            }
+        }],
+        ['Column nest/newtest/0/a has been ignored, because it treats newtest as an array, but another column does not'],
+        False
+    ),
+# Previously this caused the error: TypeError: unorderable types: str() < int()
+# Now one of the columns is ignored
+    (
+        'Mismatch of array/object for field not in schema (multiline)',
+        [
+            OrderedDict([
+                ('ROOT_ID', 1),
+                ('id', 2),
+                ('newtest/0/a', 4),
+            ]),
+            OrderedDict([
+                ('ROOT_ID', 1),
+                ('id', 2),
+                ('newtest/a', 3),
+            ])
+        ],
+        [{
+            'ROOT_ID': 1,
+            'id': 2,
+            'newtest': [
+                {'a': 4}
+            ]
+        }],
+        ['Column newtest/a has been ignored, because it treats newtest as an object, but another column does not'],
+        False
+    ),
+# Previously this caused the error: 'Cell' object has no attribute 'get'
+# Now one of the columns is ignored
+    (
+        'str / array mixing multiline',
+        [
+            OrderedDict([
+                ('ROOT_ID', 1),
+                ('id', 2),
+                ('nest/newtest', 3),
+            ]),
+            OrderedDict([
+                ('ROOT_ID', 1),
+                ('id', 2),
+                ('nest/newtest/0/a', 4),
+                ('nest/newtest/0/b', 5),
+            ]),
+        ],
+        [{
+            'ROOT_ID': 1,
+            'id': 2,
+            'nest': {
+                'newtest': 3
+            }
+        }],
+        [
+            'Column nest/newtest/0/a has been ignored, because it treats newtest as an array, but another column does not',
+            'Column nest/newtest/0/b has been ignored, because it treats newtest as an array, but another column does not',
+        ],
+        False
+    ),
+    (
+        'array / str mixing multiline',
+        # same as above, but with rows switched
+        [
+            OrderedDict([
+                ('ROOT_ID', 1),
+                ('id', 2),
+                ('nest/newtest/0/a', 4),
+            ]),
+            OrderedDict([
+                ('ROOT_ID', 1),
+                ('id', 2),
+                ('nest/newtest', 3),
+            ]),
+        ],
+        [{
+            'ROOT_ID': 1,
+            'id': 2,
+            'nest': {
+                'newtest': [
+                    {'a': 4}
+                ]
+            }
+        }],
+        ['Column nest/newtest has been ignored, because another column treats it as an array or object'],
+        False
+    ),
+# WARNING: Conflict when merging field "newtest" for id "2" in sheet custom_main: "3" 
+    (
+        'str / object mixing multiline',
+        [
+            OrderedDict([
+                ('ROOT_ID', 1),
+                ('id', 2),
+                ('newtest', 3),
+            ]),
+            OrderedDict([
+                ('ROOT_ID', 1),
+                ('id', 2),
+                ('newtest/a', 4),
+                ('newtest/b', 5),
+            ])
+        ],
+        [{
+            'ROOT_ID': 1,
+            'id': 2,
+            'newtest': 3
+        }],
+        [
+            'Column newtest/a has been ignored, because it treats newtest as an object, but another column does not',
+            'Column newtest/b has been ignored, because it treats newtest as an object, but another column does not',
+        ],
+        False
+    ),
+    (
+        'object / str mixing multiline',
+        [
+            OrderedDict([
+                ('ROOT_ID', 1),
+                ('id', 2),
+                ('newtest/a', 4),
+            ]),
+            OrderedDict([
+                ('ROOT_ID', 1),
+                ('id', 2),
+                ('newtest', 3),
+            ])
+        ],
+        [{
+            'ROOT_ID': 1,
+            'id': 2,
+            'newtest': {
+                'a': 4
+            }
+        }],
+        ['Column newtest has been ignored, because another column treats it as an array or object'],
+        False
+    ),
 # Previously this caused the error: KeyError('ocid',)
 # Now it works, but probably not as intended
 # The missing Root ID should be picked up in schema validation

--- a/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
+++ b/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
@@ -590,19 +590,15 @@ def create_schema(root_id):
                     }
                 }
             },
-            'testR': {
-                'title': 'R title',
+            'testArr': {
+                'title': 'Arr title',
                 'type': 'array',
-                'rollUp': ['id', 'testB'],
                 'items': {
                     'type': 'object',
                     'properties': {
                         'id': {
                             'title': 'Identifier',
                             'type': 'string',
-                            # 'type': 'integer',
-                            # integer does not work, as testB:integer is not
-                            # in the rollUp
                         },
                         'testB': {
                             'title': 'B title',
@@ -611,13 +607,6 @@ def create_schema(root_id):
                         'testC': {
                             'title': 'C title',
                             'type': 'string',
-                        },
-                        'testSA': {
-                            'title': 'SA title',
-                            'type': 'array',
-                            'items': {
-                                'type': 'string'
-                            }
                         },
                         'testNest': {
                             'title': 'Nest title',
@@ -648,6 +637,38 @@ def create_schema(root_id):
                                     'title': 'D title',
                                     'type': 'string',
                                 },
+                            }
+                        },
+                    }
+                }
+            },
+            'testR': {
+                'title': 'R title',
+                'type': 'array',
+                'rollUp': ['id', 'testB'],
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'id': {
+                            'title': 'Identifier',
+                            'type': 'string',
+                            # 'type': 'integer',
+                            # integer does not work, as testB:integer is not
+                            # in the rollUp
+                        },
+                        'testB': {
+                            'title': 'B title',
+                            'type': 'string',
+                        },
+                        'testC': {
+                            'title': 'C title',
+                            'type': 'string',
+                        },
+                        'testSA': {
+                            'title': 'SA title',
+                            'type': 'array',
+                            'items': {
+                                'type': 'string'
                             }
                         },
                     }

--- a/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
+++ b/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
@@ -559,6 +559,10 @@ def create_schema(root_id):
                 'title': 'B title',
                 'type': 'object',
                 'properties': {
+                    'id': {
+                        'title': 'Identifier',
+                        'type': 'integer',
+                    },
                     'testC': {
                         'title': 'C title',
                         'type': 'integer',
@@ -566,6 +570,23 @@ def create_schema(root_id):
                     'testD': {
                         'title': 'D title',
                         'type': 'integer',
+                    },
+                    'subField': {
+                        'title': 'Sub title',
+                        'type': 'array',
+                        'items': {
+                            'type': 'object',
+                            'properties': {
+                                'id': {
+                                    'title': 'Identifier',
+                                    'type': 'integer',
+                                },
+                                'testE': {
+                                    'title': 'E title',
+                                    'type': 'integer',
+                                },
+                            }
+                        }
                     }
                 }
             },
@@ -597,7 +618,38 @@ def create_schema(root_id):
                             'items': {
                                 'type': 'string'
                             }
-                        }
+                        },
+                        'testNest': {
+                            'title': 'Nest title',
+                            'type': 'array',
+                            'items': {
+                                'type': 'object',
+                                'properties': {
+                                    'id': {
+                                        'title': 'Identifier',
+                                        'type': 'string',
+                                    },
+                                    'testD': {
+                                        'title': 'D title',
+                                        'type': 'string',
+                                    },
+                                }
+                            }
+                        },
+                        'testNestObj': {
+                            'title': 'NestObj title',
+                            'type': 'object',
+                            'properties': {
+                                'id': {
+                                    'title': 'Identifier',
+                                    'type': 'string',
+                                },
+                                'testD': {
+                                    'title': 'D title',
+                                    'type': 'string',
+                                },
+                            }
+                        },
                     }
                 }
             },

--- a/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
+++ b/flattentool/tests/test_input_SpreadsheetInput_unflatten.py
@@ -26,16 +26,20 @@ def inject_root_id(root_id, d):
     """
     Insert the appropriate root id, with the given value, into the dictionary d and return.
     """
-    d = copy.copy(d)
-    if 'ROOT_ID' in d:
-        if root_id != '':
-            d.update({root_id: d['ROOT_ID']})
-        del d['ROOT_ID']
-    if 'ROOT_ID_TITLE' in d:
-        if root_id != '':
-            d.update({ROOT_ID_TITLES[root_id]: d['ROOT_ID_TITLE']})
-        del d['ROOT_ID_TITLE']
-    return d
+    new_d = type(d)()
+    for k, v in d.items():
+        if k == 'ROOT_ID':
+            if root_id == '':
+                continue
+            else:
+                k = root_id
+        elif k == 'ROOT_ID_TITLE':
+            if root_id == '':
+                continue
+            else:
+                k = ROOT_ID_TITLES[root_id]
+        new_d[k] = v
+    return new_d
 
 
 UNICODE_TEST_STRING = 'éαГ😼𝒞人'

--- a/flattentool/tests/test_input_SpreadsheetInput_unflatten_mulitplesheets.py
+++ b/flattentool/tests/test_input_SpreadsheetInput_unflatten_mulitplesheets.py
@@ -363,7 +363,7 @@ testdata_multiplesheets = [
 
 
 
-testdata_pointer = [
+testdata_multiplesheets_pointer = [
     (
         'with schema',
         {
@@ -392,6 +392,349 @@ testdata_pointer = [
             }]
         }],
         []
+    )
+]
+
+
+testdata_multiplesheets_titles = [
+    (
+        'Basic sub sheet',
+        {
+            'custom_main': [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                },
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 3,
+                }
+            ],
+            'testR': [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'R title:C title': '3',
+                },
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'R title:C title': '4',
+                }
+            ]
+        },
+        [
+            {
+                'ROOT_ID': 1,
+                'id': 2,
+                'testR': [
+                    {'testC': '3'},
+                    {'testC': '4'},
+                ]
+            },
+            {
+                'ROOT_ID': 1,
+                'id': 3
+            }
+        ],
+        [],
+        True
+    ),
+    (
+        'Nested sub sheet (with id)',
+        {
+            'custom_main': [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'B title:Identifier': 3,
+                    'B title:C title': 4,
+                }
+            ],
+            'tes_subField': [
+                # It used to be neccesary to supply testA/id in this
+                # situation, but now it's optional
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'B title:Identifier': 3,
+                    'B title:Sub title:E title': 5,
+                }
+            ]
+        },
+        [
+            {'ROOT_ID': 1, 'id': 2, 'testB': {
+                'id': 3,
+                'testC': 4,
+                'subField': [{'testE': 5}]
+            }}
+        ],
+        [],
+        True
+    ),
+    (
+        'Nested sub sheet (without id)',
+        {
+            'custom_main': [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'B title:Identifier': 3,
+                    'B title:C title': 4,
+                }
+            ],
+            'sub': [
+                # It used to be neccesary to supply testA/id in this
+                # situation, but now it's optional
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'B title:Sub title:E title': 5,
+                }
+            ]
+        },
+        [
+            {'ROOT_ID': 1, 'id': 2, 'testB': {
+                'id': 3,
+                'testC': 4,
+                'subField': [{'testE': 5}]
+            }}
+        ],
+        [],
+        False
+    ),
+    (
+        'Basic two sub sheets',
+        OrderedDict([
+            ('custom_main', [
+                OrderedDict([
+                    ('ROOT_ID', 1),
+                    ('Identifier', 2),
+                ]),
+                OrderedDict([
+                    ('ROOT_ID', 1),
+                    ('Identifier', 6),
+                ])
+            ]),
+            ('testR', [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'R title:Identifier': '3',
+                    'R title:B title': '4',
+                }
+            ]),
+            ('tes_testNest', [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'R title:Identifier': '3',
+                    'R title:Nest title:D title': '5',
+                }
+            ])
+        ]),
+        [
+            OrderedDict([
+                ('ROOT_ID', 1),
+                ('id', 2),
+                ('testR', [
+                    {
+                        'id': '3',
+                        'testB': '4',
+                        'testNest': [
+                            {
+                                'testD': '5'
+                            }
+                        ]
+                    }
+                ])
+            ]),
+            {
+                'ROOT_ID':1,
+                'id': 6
+            }
+        ],
+        [],
+        True
+    ),
+   (
+       'Nested id',
+        {
+           'custom_main': [
+               {
+                   'ROOT_ID': 1,
+                   'Identifier': 2,
+               }
+           ],
+           'testR': [
+               {
+                   'ROOT_ID': 1,
+                   'Identifier': 2,
+                   'R title:Identifier': '3',
+                   'R title:NestObj title:Identifier': '4',
+               }
+           ]
+       },
+       [{'ROOT_ID': 1, 'id': 2, 'testR': [{'id': '3', 'testNestObj': {'id': '4'}}]}],
+       [],
+       True
+   ),
+    (
+        'Missing columns',
+        {
+            'custom_main': [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                }
+            ],
+            'sub': [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': '',
+                    'R title:Identifier': 3,
+                    'R title:B title': 4,
+                },
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'R title:Identifier': 3,
+                    'R title:B title': 5,
+                }
+            ]
+        },
+        [
+            {'ROOT_ID': 1, 'id': 2, 'testR': [{'id': '3', 'testB': '5'}]},
+            {'ROOT_ID': 1, 'testR': [{'id': '3', 'testB': '4'}]},
+        ],
+        [],
+        False
+    ),
+    (
+        'Unmatched id',
+        OrderedDict([
+            ('custom_main', [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                }
+            ]),
+            ('sub', [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 100,
+                    'R title:Identifier': 3,
+                    'R title:B title': 4,
+                },
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'R title:Identifier': 3,
+                    'R title:B title': 5,
+                }
+            ])
+        ]),
+        [
+            {'ROOT_ID': 1, 'id': 2, 'testR': [{'id': '3', 'testB': '5'}]},
+            {'ROOT_ID': 1, 'id': 100, 'testR': [{'id': '3', 'testB': '4'}]},
+        ],
+        [],
+        False
+    ),
+    (
+        'Test same rollup',
+        {
+            'main': [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'A title': 3,
+                    'R title:Identifier': 4,
+                    'R title:B title': 5,
+                },
+                {
+                    'ROOT_ID': 6,
+                    'Identifier': 7,
+                    'A title': 8,
+                    'R title:B title': 9,
+                }
+            ],
+            'testR': [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'R title:Identifier': 4,
+                    'R title:B title': 5,
+                },
+                {
+                    'ROOT_ID': 6,
+                    'Identifier': 7,
+                    'R title:B title': 9,
+                }
+            ]
+        },
+        [
+            {'ROOT_ID': 1, 'id': 2, 'testA':3, 'testR': [{'id': '4', 'testB': '5'}]},
+            {'ROOT_ID': 6, 'id': 7, 'testA':8, 'testR': [
+                {'testB': '9'}, {'testB': '9'}
+                # We have duplicates here because there's no ID to merge these
+                # on. This is different to the old behaviour. Issue filed at
+                # https://github.com/OpenDataServices/flatten-tool/issues/99
+            ]},
+        ],
+        [],
+        False
+    ),
+    (
+        'Test conflicting rollup',
+        OrderedDict([
+            ('main', [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'R title:Identifier': '3',
+                    'R title:B title': '4'
+                }
+            ]),
+            ('testR', [
+                {
+                    'ROOT_ID': 1,
+                    'Identifier': 2,
+                    'R title:Identifier': '3',
+                    'R title:B title': '5',
+                }
+            ])
+        ]),
+        [
+            {
+                'ROOT_ID': 1,
+                'id': 2,
+                'testR': [{
+                    'id': '3',
+                    'testB': '4'
+                    # (Since sheets are parsed in the order they appear, and the first value is used).
+                }]
+            }
+        ],
+        ['Conflict when merging field "testB" for ROOT_ID "1", id "2" in sheet testA: "4" != "5"'],
+        False
+    ),
+    (
+        'Unflatten empty',
+        {
+            'custom_main': [],
+            'subsheet': [
+                {
+                    'ROOT_ID': '',
+                    'Identifier': '',
+                    'A title': '',
+                    'U title': '',
+                }
+            ]
+        },
+        [],
+        [],
+        False
     )
 ]
 
@@ -425,6 +768,22 @@ def test_unflatten(convert_titles, use_schema, root_id, root_id_kwargs, input_di
 
 @pytest.mark.parametrize('convert_titles', [True, False])
 @pytest.mark.parametrize('root_id,root_id_kwargs', ROOT_ID_PARAMS)
-@pytest.mark.parametrize('comment,input_dict,expected_output_list,warning_messages', testdata_pointer)
+@pytest.mark.parametrize('comment,input_dict,expected_output_list,warning_messages', testdata_multiplesheets_pointer)
 def test_unflatten_pointer(convert_titles, root_id, root_id_kwargs, input_dict, expected_output_list, recwarn, comment, warning_messages):
     return test_unflatten(convert_titles=convert_titles, use_schema=True, root_id=root_id, root_id_kwargs=root_id_kwargs, input_dict=input_dict, expected_output_list=expected_output_list, recwarn=recwarn, comment=comment, warning_messages=warning_messages, reversible=False)
+
+
+@pytest.mark.parametrize('comment,input_dict,expected_output_list,warning_messages,reversible', testdata_multiplesheets_titles)
+@pytest.mark.parametrize('root_id,root_id_kwargs', ROOT_ID_PARAMS)
+def test_unflatten_titles(root_id, root_id_kwargs, input_dict, expected_output_list, recwarn, comment, warning_messages, reversible):
+    """
+    Essentially the same as test unflatten, except that convert_titles and
+    use_schema are always true, as both of these are needed to convert titles
+    properly. (and runs with different test data).
+    """
+    if root_id != '':
+        # Skip all tests with a root ID for now, as this is broken
+        # https://github.com/OpenDataServices/flatten-tool/issues/84
+        pytest.skip()
+    return test_unflatten(convert_titles=True, use_schema=True, root_id=root_id, root_id_kwargs=root_id_kwargs, input_dict=input_dict, expected_output_list=expected_output_list, recwarn=recwarn, comment=comment, warning_messages=warning_messages, reversible=reversible)
+

--- a/flattentool/tests/test_input_SpreadsheetInput_unflatten_mulitplesheets.py
+++ b/flattentool/tests/test_input_SpreadsheetInput_unflatten_mulitplesheets.py
@@ -31,16 +31,16 @@ testdata_multiplesheets = [
                     'id': 3,
                 }
             ],
-            'testR': [
+            'testArr': [
                 {
                     'ROOT_ID': 1,
                     'id': 2,
-                    'testR/0/testC': '3',
+                    'testArr/0/testC': '3',
                 },
                 {
                     'ROOT_ID': 1,
                     'id': 2,
-                    'testR/0/testC': '4',
+                    'testArr/0/testC': '4',
                 }
             ]
         },
@@ -48,7 +48,7 @@ testdata_multiplesheets = [
             {
                 'ROOT_ID': 1,
                 'id': 2,
-                'testR': [
+                'testArr': [
                     {'testC': '3'},
                     {'testC': '4'},
                 ]
@@ -270,33 +270,33 @@ testdata_multiplesheets = [
                     'ROOT_ID': 1,
                     'id': 2,
                     'testC': 3,
-                    'testR/0/id': '4',
-                    'testR/0/testB': '5',
+                    'testArr/0/id': '4',
+                    'testArr/0/testB': '5',
                 },
                 {
                     'ROOT_ID': 6,
                     'id': 7,
                     'testC': 8,
-                    'testR/0/testB': '9',
+                    'testArr/0/testB': '9',
                 }
             ],
-            'testR': [
+            'testArr': [
                 {
                     'ROOT_ID': 1,
                     'id': 2,
-                    'testR/0/id': '4',
-                    'testR/0/testB': '5',
+                    'testArr/0/id': '4',
+                    'testArr/0/testB': '5',
                 },
                 {
                     'ROOT_ID': 6,
                     'id': 7,
-                    'testR/0/testB': '9',
+                    'testArr/0/testB': '9',
                 }
             ]
         },
         [
-            {'ROOT_ID': 1, 'id': 2, 'testC':3, 'testR': [{'id': '4', 'testB': '5'}]},
-            {'ROOT_ID': 6, 'id': 7, 'testC':8, 'testR': [
+            {'ROOT_ID': 1, 'id': 2, 'testC':3, 'testArr': [{'id': '4', 'testB': '5'}]},
+            {'ROOT_ID': 6, 'id': 7, 'testC':8, 'testArr': [
                 {'testB': '9'}, {'testB': '9'}
                 # We have duplicates here because there's no ID to merge these
                 # on. This is different to the old behaviour. Issue filed at
@@ -313,16 +313,16 @@ testdata_multiplesheets = [
                 {
                     'ROOT_ID': 1,
                     'id': 2,
-                    'testR/0/id': '3',
-                    'testR/0/testB': '4'
+                    'testArr/0/id': '3',
+                    'testArr/0/testB': '4'
                 }
             ]),
-            ('testR', [
+            ('testArr', [
                 {
                     'ROOT_ID': 1,
                     'id': 2,
-                    'testR/0/id': '3',
-                    'testR/0/testB': '5',
+                    'testArr/0/id': '3',
+                    'testArr/0/testB': '5',
                 }
             ])
         ]),
@@ -330,7 +330,7 @@ testdata_multiplesheets = [
             {
                 'ROOT_ID': 1,
                 'id': 2,
-                'testR': [{
+                'testArr': [{
                     'id': '3',
                     'testB': '4'
                     # (Since sheets are parsed in the order they appear, and the first value is used).
@@ -378,7 +378,7 @@ testdata_multiplesheets_pointer = [
                 {
                     'ROOT_ID': 1,
                     'id': 2,
-                    'testR/testB': 4 # test that we can infer this an array from schema
+                    'testArr/testB': 4 # test that we can infer this an array from schema
                 }
             ]
         },
@@ -387,7 +387,7 @@ testdata_multiplesheets_pointer = [
             'id': 2, # check that we join correctly when this gets converted to an
                      # integer because of the schema type
             'testA': 3,
-            'testR': [{
+            'testArr': [{
                 'testB': '4'
             }]
         }],
@@ -410,16 +410,16 @@ testdata_multiplesheets_titles = [
                     'Identifier': 3,
                 }
             ],
-            'testR': [
+            'testArr': [
                 {
                     'ROOT_ID': 1,
                     'Identifier': 2,
-                    'R title:C title': '3',
+                    'Arr title:C title': '3',
                 },
                 {
                     'ROOT_ID': 1,
                     'Identifier': 2,
-                    'R title:C title': '4',
+                    'Arr title:C title': '4',
                 }
             ]
         },
@@ -427,7 +427,7 @@ testdata_multiplesheets_titles = [
             {
                 'ROOT_ID': 1,
                 'id': 2,
-                'testR': [
+                'testArr': [
                     {'testC': '3'},
                     {'testC': '4'},
                 ]
@@ -516,20 +516,20 @@ testdata_multiplesheets_titles = [
                     ('Identifier', 6),
                 ])
             ]),
-            ('testR', [
+            ('testArr', [
                 {
                     'ROOT_ID': 1,
                     'Identifier': 2,
-                    'R title:Identifier': '3',
-                    'R title:B title': '4',
+                    'Arr title:Identifier': '3',
+                    'Arr title:B title': '4',
                 }
             ]),
             ('tes_testNest', [
                 {
                     'ROOT_ID': 1,
                     'Identifier': 2,
-                    'R title:Identifier': '3',
-                    'R title:Nest title:D title': '5',
+                    'Arr title:Identifier': '3',
+                    'Arr title:Nest title:D title': '5',
                 }
             ])
         ]),
@@ -537,7 +537,7 @@ testdata_multiplesheets_titles = [
             OrderedDict([
                 ('ROOT_ID', 1),
                 ('id', 2),
-                ('testR', [
+                ('testArr', [
                     {
                         'id': '3',
                         'testB': '4',
@@ -566,16 +566,16 @@ testdata_multiplesheets_titles = [
                    'Identifier': 2,
                }
            ],
-           'testR': [
+           'testArr': [
                {
                    'ROOT_ID': 1,
                    'Identifier': 2,
-                   'R title:Identifier': '3',
-                   'R title:NestObj title:Identifier': '4',
+                   'Arr title:Identifier': '3',
+                   'Arr title:NestObj title:Identifier': '4',
                }
            ]
        },
-       [{'ROOT_ID': 1, 'id': 2, 'testR': [{'id': '3', 'testNestObj': {'id': '4'}}]}],
+       [{'ROOT_ID': 1, 'id': 2, 'testArr': [{'id': '3', 'testNestObj': {'id': '4'}}]}],
        [],
        True
    ),
@@ -592,20 +592,20 @@ testdata_multiplesheets_titles = [
                 {
                     'ROOT_ID': 1,
                     'Identifier': '',
-                    'R title:Identifier': 3,
-                    'R title:B title': 4,
+                    'Arr title:Identifier': 3,
+                    'Arr title:B title': 4,
                 },
                 {
                     'ROOT_ID': 1,
                     'Identifier': 2,
-                    'R title:Identifier': 3,
-                    'R title:B title': 5,
+                    'Arr title:Identifier': 3,
+                    'Arr title:B title': 5,
                 }
             ]
         },
         [
-            {'ROOT_ID': 1, 'id': 2, 'testR': [{'id': '3', 'testB': '5'}]},
-            {'ROOT_ID': 1, 'testR': [{'id': '3', 'testB': '4'}]},
+            {'ROOT_ID': 1, 'id': 2, 'testArr': [{'id': '3', 'testB': '5'}]},
+            {'ROOT_ID': 1, 'testArr': [{'id': '3', 'testB': '4'}]},
         ],
         [],
         False
@@ -623,20 +623,20 @@ testdata_multiplesheets_titles = [
                 {
                     'ROOT_ID': 1,
                     'Identifier': 100,
-                    'R title:Identifier': 3,
-                    'R title:B title': 4,
+                    'Arr title:Identifier': 3,
+                    'Arr title:B title': 4,
                 },
                 {
                     'ROOT_ID': 1,
                     'Identifier': 2,
-                    'R title:Identifier': 3,
-                    'R title:B title': 5,
+                    'Arr title:Identifier': 3,
+                    'Arr title:B title': 5,
                 }
             ])
         ]),
         [
-            {'ROOT_ID': 1, 'id': 2, 'testR': [{'id': '3', 'testB': '5'}]},
-            {'ROOT_ID': 1, 'id': 100, 'testR': [{'id': '3', 'testB': '4'}]},
+            {'ROOT_ID': 1, 'id': 2, 'testArr': [{'id': '3', 'testB': '5'}]},
+            {'ROOT_ID': 1, 'id': 100, 'testArr': [{'id': '3', 'testB': '4'}]},
         ],
         [],
         False
@@ -649,33 +649,33 @@ testdata_multiplesheets_titles = [
                     'ROOT_ID': 1,
                     'Identifier': 2,
                     'A title': 3,
-                    'R title:Identifier': 4,
-                    'R title:B title': 5,
+                    'Arr title:Identifier': 4,
+                    'Arr title:B title': 5,
                 },
                 {
                     'ROOT_ID': 6,
                     'Identifier': 7,
                     'A title': 8,
-                    'R title:B title': 9,
+                    'Arr title:B title': 9,
                 }
             ],
-            'testR': [
+            'testArr': [
                 {
                     'ROOT_ID': 1,
                     'Identifier': 2,
-                    'R title:Identifier': 4,
-                    'R title:B title': 5,
+                    'Arr title:Identifier': 4,
+                    'Arr title:B title': 5,
                 },
                 {
                     'ROOT_ID': 6,
                     'Identifier': 7,
-                    'R title:B title': 9,
+                    'Arr title:B title': 9,
                 }
             ]
         },
         [
-            {'ROOT_ID': 1, 'id': 2, 'testA':3, 'testR': [{'id': '4', 'testB': '5'}]},
-            {'ROOT_ID': 6, 'id': 7, 'testA':8, 'testR': [
+            {'ROOT_ID': 1, 'id': 2, 'testA':3, 'testArr': [{'id': '4', 'testB': '5'}]},
+            {'ROOT_ID': 6, 'id': 7, 'testA':8, 'testArr': [
                 {'testB': '9'}, {'testB': '9'}
                 # We have duplicates here because there's no ID to merge these
                 # on. This is different to the old behaviour. Issue filed at
@@ -692,16 +692,16 @@ testdata_multiplesheets_titles = [
                 {
                     'ROOT_ID': 1,
                     'Identifier': 2,
-                    'R title:Identifier': '3',
-                    'R title:B title': '4'
+                    'Arr title:Identifier': '3',
+                    'Arr title:B title': '4'
                 }
             ]),
-            ('testR', [
+            ('testArr', [
                 {
                     'ROOT_ID': 1,
                     'Identifier': 2,
-                    'R title:Identifier': '3',
-                    'R title:B title': '5',
+                    'Arr title:Identifier': '3',
+                    'Arr title:B title': '5',
                 }
             ])
         ]),
@@ -709,7 +709,7 @@ testdata_multiplesheets_titles = [
             {
                 'ROOT_ID': 1,
                 'id': 2,
-                'testR': [{
+                'testArr': [{
                     'id': '3',
                     'testB': '4'
                     # (Since sheets are parsed in the order they appear, and the first value is used).

--- a/flattentool/tests/test_json_input_is_unflatten_reversed.py
+++ b/flattentool/tests/test_json_input_is_unflatten_reversed.py
@@ -4,7 +4,7 @@ testdata in reverse.
 '''
 
 from .test_input_SpreadsheetInput_unflatten import ROOT_ID_PARAMS, testdata, testdata_titles, create_schema, inject_root_id
-from .test_input_SpreadsheetInput_unflatten_mulitplesheets import testdata_multiplesheets
+from .test_input_SpreadsheetInput_unflatten_mulitplesheets import testdata_multiplesheets, testdata_multiplesheets_titles
 from flattentool.json_input import JSONParser
 from flattentool.schema import SchemaParser
 from collections import OrderedDict
@@ -112,3 +112,19 @@ def test_flatten_multiplesheets(use_titles, use_schema, root_id, root_id_kwargs,
     output = {sheet_name:sheet.lines for sheet_name, sheet in parser.sub_sheets.items() if sheet.lines}
     output['custom_main'] = parser.main_sheet.lines
     assert output == expected_output_dict
+
+
+@pytest.mark.parametrize('comment,expected_output_dict,input_list,warning_messages,reversible', [x for x in testdata_multiplesheets_titles if x[4]])
+@pytest.mark.parametrize('root_id,root_id_kwargs', ROOT_ID_PARAMS)
+def test_flatten_multiplesheets_titles(root_id, root_id_kwargs, input_list, expected_output_dict, recwarn, comment, warning_messages, reversible, tmpdir):
+    """
+    Essentially the same as test unflatten, except that convert_titles and
+    use_schema are always true, as both of these are needed to convert titles
+    properly. (and runs with different test data).
+    """
+    if root_id != '':
+        # Skip all tests with a root ID for now, as this is broken
+        # https://github.com/OpenDataServices/flatten-tool/issues/84
+        pytest.skip()
+    return test_flatten_multiplesheets(use_titles=True, use_schema=True, root_id=root_id, root_id_kwargs=root_id_kwargs, input_list=input_list, expected_output_dict=expected_output_dict, recwarn=recwarn, comment=comment, warning_messages=warning_messages, reversible=reversible, tmpdir=tmpdir)
+

--- a/flattentool/tests/test_json_input_is_unflatten_reversed.py
+++ b/flattentool/tests/test_json_input_is_unflatten_reversed.py
@@ -4,8 +4,10 @@ testdata in reverse.
 '''
 
 from .test_input_SpreadsheetInput_unflatten import ROOT_ID_PARAMS, testdata, testdata_titles, create_schema, inject_root_id
+from .test_input_SpreadsheetInput_unflatten_mulitplesheets import testdata_multiplesheets
 from flattentool.json_input import JSONParser
 from flattentool.schema import SchemaParser
+from collections import OrderedDict
 import pytest
 import json
 
@@ -71,3 +73,48 @@ def test_flatten_titles(root_id, root_id_kwargs, input_list, expected_output_lis
         pytest.skip()
     return test_flatten(use_titles=True, use_schema=True, root_id=root_id, root_id_kwargs=root_id_kwargs, input_list=input_list, expected_output_list=expected_output_list, recwarn=recwarn, comment=comment, warning_messages=warning_messages, reversible=reversible, tmpdir=tmpdir)
 
+
+
+# Don't test with use_titles and use_schema true because this will will use
+# titles, which the fixtures don't
+@pytest.mark.parametrize('use_titles,use_schema', [(False, False), (True, False), (False, True)])
+@pytest.mark.parametrize('root_id,root_id_kwargs', ROOT_ID_PARAMS)
+@pytest.mark.parametrize('comment,expected_output_dict,input_list,warning_messages,reversible', testdata_multiplesheets)
+def test_flatten_multiplesheets(use_titles, use_schema, root_id, root_id_kwargs, input_list, expected_output_dict, recwarn, comment, warning_messages, tmpdir, reversible):
+    if not reversible:
+        pytest.skip()
+
+    # Not sure why, but this seems to be necessary to have warnings picked up
+    # on Python 2.7 and 3.3, but 3.4 and 3.5 are fine without it
+    import warnings
+    warnings.simplefilter('always')
+
+    extra_kwargs = {'use_titles': use_titles}
+    extra_kwargs.update(root_id_kwargs)
+    
+    if use_schema:
+        schema_parser = SchemaParser(
+            root_schema_dict=create_schema(root_id) if use_schema else {"properties": {}},
+            rollup=True,
+            **extra_kwargs
+        )
+        schema_parser.parse()
+    else:
+        schema_parser = None
+
+    with tmpdir.join('input.json').open('w') as fp:
+        json.dump({
+            'mykey': [inject_root_id(root_id, input_row) for input_row in input_list]
+        }, fp)
+
+    parser = JSONParser(
+        json_filename=tmpdir.join('input.json').strpath,
+        root_list_path='mykey',
+        schema_parser=schema_parser,
+        **extra_kwargs)
+    parser.parse()
+
+    expected_output_dict = OrderedDict([(sheet_name, [inject_root_id(root_id, line) for line in lines]) for sheet_name, lines in expected_output_dict.items()])
+    output = {sheet_name:sheet.lines for sheet_name, sheet in parser.sub_sheets.items() if sheet.lines}
+    output['custom_main'] = parser.main_sheet.lines
+    assert output == expected_output_dict

--- a/flattentool/tests/test_json_input_is_unflatten_reversed.py
+++ b/flattentool/tests/test_json_input_is_unflatten_reversed.py
@@ -15,11 +15,8 @@ import json
 # titles, which the fixtures don't
 @pytest.mark.parametrize('use_titles,use_schema', [(False, False), (True, False), (False, True)])
 @pytest.mark.parametrize('root_id,root_id_kwargs', ROOT_ID_PARAMS)
-@pytest.mark.parametrize('comment,expected_output_list,input_list,warning_messages,reversible', testdata)
+@pytest.mark.parametrize('comment,expected_output_list,input_list,warning_messages,reversible', [x for x in testdata if x[4]])
 def test_flatten(use_titles, use_schema, root_id, root_id_kwargs, input_list, expected_output_list, recwarn, comment, warning_messages, tmpdir, reversible):
-    if not reversible:
-        pytest.skip()
-
     # Not sure why, but this seems to be necessary to have warnings picked up
     # on Python 2.7 and 3.3, but 3.4 and 3.5 are fine without it
     import warnings
@@ -59,7 +56,7 @@ def test_flatten(use_titles, use_schema, root_id, root_id_kwargs, input_list, ex
     assert list(parser.main_sheet.lines) == expected_output_list
 
 
-@pytest.mark.parametrize('comment,expected_output_list,input_list,warning_messages,reversible', testdata_titles)
+@pytest.mark.parametrize('comment,expected_output_list,input_list,warning_messages,reversible', [x for x in testdata_titles if x[4]])
 @pytest.mark.parametrize('root_id,root_id_kwargs', ROOT_ID_PARAMS)
 def test_flatten_titles(root_id, root_id_kwargs, input_list, expected_output_list, recwarn, comment, warning_messages, reversible, tmpdir):
     """
@@ -79,11 +76,8 @@ def test_flatten_titles(root_id, root_id_kwargs, input_list, expected_output_lis
 # titles, which the fixtures don't
 @pytest.mark.parametrize('use_titles,use_schema', [(False, False), (True, False), (False, True)])
 @pytest.mark.parametrize('root_id,root_id_kwargs', ROOT_ID_PARAMS)
-@pytest.mark.parametrize('comment,expected_output_dict,input_list,warning_messages,reversible', testdata_multiplesheets)
+@pytest.mark.parametrize('comment,expected_output_dict,input_list,warning_messages,reversible', [x for x in testdata_multiplesheets if x[4]])
 def test_flatten_multiplesheets(use_titles, use_schema, root_id, root_id_kwargs, input_list, expected_output_dict, recwarn, comment, warning_messages, tmpdir, reversible):
-    if not reversible:
-        pytest.skip()
-
     # Not sure why, but this seems to be necessary to have warnings picked up
     # on Python 2.7 and 3.3, but 3.4 and 3.5 are fine without it
     import warnings

--- a/flattentool/tests/test_json_input_is_unflatten_reversed.py
+++ b/flattentool/tests/test_json_input_is_unflatten_reversed.py
@@ -1,0 +1,73 @@
+'''
+Test flattening (JSON input) by checking that we can run some of the unflatten
+testdata in reverse.
+'''
+
+from .test_input_SpreadsheetInput_unflatten import ROOT_ID_PARAMS, testdata, testdata_titles, create_schema, inject_root_id
+from flattentool.json_input import JSONParser
+from flattentool.schema import SchemaParser
+import pytest
+import json
+
+# Don't test with use_titles and use_schema true because this will will use
+# titles, which the fixtures don't
+@pytest.mark.parametrize('use_titles,use_schema', [(False, False), (True, False), (False, True)])
+@pytest.mark.parametrize('root_id,root_id_kwargs', ROOT_ID_PARAMS)
+@pytest.mark.parametrize('comment,expected_output_list,input_list,warning_messages,reversible', testdata)
+def test_flatten(use_titles, use_schema, root_id, root_id_kwargs, input_list, expected_output_list, recwarn, comment, warning_messages, tmpdir, reversible):
+    if not reversible:
+        pytest.skip()
+
+    # Not sure why, but this seems to be necessary to have warnings picked up
+    # on Python 2.7 and 3.3, but 3.4 and 3.5 are fine without it
+    import warnings
+    warnings.simplefilter('always')
+
+    extra_kwargs = {'use_titles': use_titles}
+    extra_kwargs.update(root_id_kwargs)
+    
+    if use_schema:
+        schema_parser = SchemaParser(
+            root_schema_dict=create_schema(root_id) if use_schema else {"properties": {}},
+            rollup=True,
+            **extra_kwargs
+        )
+        schema_parser.parse()
+    else:
+        schema_parser = None
+
+    with tmpdir.join('input.json').open('w') as fp:
+        json.dump({
+            'mykey': [inject_root_id(root_id, input_row) for input_row in input_list]
+        }, fp)
+
+    parser = JSONParser(
+        json_filename=tmpdir.join('input.json').strpath,
+        root_list_path='mykey',
+        schema_parser=schema_parser,
+        **extra_kwargs)
+    parser.parse()
+
+    expected_output_list = [
+        inject_root_id(root_id, expected_output_dict) for expected_output_dict in expected_output_list
+    ]
+    if expected_output_list == [{}]:
+        # We don't expect an empty dictionary
+        expected_output_list = []
+    assert list(parser.main_sheet.lines) == expected_output_list
+
+
+@pytest.mark.parametrize('comment,expected_output_list,input_list,warning_messages,reversible', testdata_titles)
+@pytest.mark.parametrize('root_id,root_id_kwargs', ROOT_ID_PARAMS)
+def test_flatten_titles(root_id, root_id_kwargs, input_list, expected_output_list, recwarn, comment, warning_messages, reversible, tmpdir):
+    """
+    Essentially the same as test unflatten, except that convert_titles and
+    use_schema are always true, as both of these are needed to convert titles
+    properly. (and runs with different test data).
+    """
+    if root_id != '':
+        # Skip all tests with a root ID for now, as this is broken
+        # https://github.com/OpenDataServices/flatten-tool/issues/84
+        pytest.skip()
+    return test_flatten(use_titles=True, use_schema=True, root_id=root_id, root_id_kwargs=root_id_kwargs, input_list=input_list, expected_output_list=expected_output_list, recwarn=recwarn, comment=comment, warning_messages=warning_messages, reversible=reversible, tmpdir=tmpdir)
+

--- a/flattentool/tests/test_roundtrip.py
+++ b/flattentool/tests/test_roundtrip.py
@@ -2,6 +2,7 @@ from flattentool import unflatten, flatten
 import json
 import pytest
 import sys
+import os
 
 
 @pytest.mark.parametrize('output_format', ['xlsx', 'csv'])
@@ -57,4 +58,38 @@ def test_roundtrip_360(tmpdir, output_format, use_titles):
     original_json = json.load(open(input_name))
     roundtripped_json = json.load(tmpdir.join('roundtrip.json'))
 
+    assert original_json == roundtripped_json
+
+
+@pytest.mark.parametrize('use_titles', [False, True])
+def test_roundtrip_360_rollup(tmpdir, use_titles):
+    input_name = 'flattentool/tests/fixtures/WellcomeTrust-grants_fixed_2_grants.json'
+    output_format = 'csv'
+    output_name = tmpdir.join('flattened').strpath+'.'+output_format
+    moved_name = tmpdir.mkdir('flattened_main_only').strpath
+
+    flatten(
+        input_name=input_name,
+        output_name=output_name,
+        output_format=output_format,
+        schema='flattentool/tests/fixtures/360-giving-schema.json',
+        root_list_path='grants',
+        root_id='',
+        use_titles=use_titles,
+        rollup=True,
+        main_sheet_name='grants')
+
+    os.rename(output_name+'/grants.csv', moved_name+'/grants.csv')
+
+    unflatten(
+        input_name=moved_name,
+        output_name=tmpdir.join('roundtrip.json').strpath,
+        input_format=output_format,
+        schema='flattentool/tests/fixtures/360-giving-schema.json',
+        root_list_path='grants',
+        root_id='',
+        convert_titles=use_titles)
+
+    original_json = json.load(open(input_name))
+    roundtripped_json = json.load(tmpdir.join('roundtrip.json'))
     assert original_json == roundtripped_json


### PR DESCRIPTION
* Add new tests of titles support #77 - flattenting, and multi sheet tests for flattening and unflattening
* Fixing flattening with titles, using new tests to help
* Better warnings for headings that conflict, but not in the same row
* More thorough, parametrized tests for flattening, and multiplesheet unflattening
* Roundtrip test of using rollup https://github.com/OpenDataServices/flatten-tool/issues/67
* Fixing rollup with titles, which was shown to be broken by those tests