### PR TITLE
Remove default unflatten output-name because default is stdout

### DIFF
--- a/examples/help/unflatten/expected.txt
+++ b/examples/help/unflatten/expected.txt
@@ -33,7 +33,7 @@ optional arguments:
                         Defaults to utf8.
   -o OUTPUT_NAME, --output-name OUTPUT_NAME
                         Name of the outputted file. Will have an extension
-                        appended as appropriate. Defaults to unflattened.json
+                        appended as appropriate.
   -c CELL_SOURCE_MAP, --cell-source-map CELL_SOURCE_MAP
                         Path to write a cell source map to. Will have an
                         extension appended as appropriate.

--- a/flattentool/cli.py
+++ b/flattentool/cli.py
@@ -124,7 +124,7 @@ def create_parser():
         help="Encoding of the input file(s) (only relevant for CSV). This can be any encoding recognised by Python. Defaults to utf8.")
     parser_unflatten.add_argument(
         "-o", "--output-name",
-        help="Name of the outputted file. Will have an extension appended as appropriate. Defaults to unflattened.json")
+        help="Name of the outputted file. Will have an extension appended as appropriate.")
     parser_unflatten.add_argument(
         "-c", "--cell-source-map",
         help="Path to write a cell source map to. Will have an extension appended as appropriate.")


### PR DESCRIPTION
Fixes #190.