### PR TITLE
Avoid some openpyxl warnings by not using deprecated method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 # Apparently six must be installed first, otherwise setup.py will be unhappy
 install:
   - pip install six

--- a/flattentool/input.py
+++ b/flattentool/input.py
@@ -555,7 +555,7 @@ class XLSXInput(SpreadsheetInput):
     def read_sheets(self):
         self.workbook = openpyxl.load_workbook(self.input_name, data_only=True)
 
-        self.sheet_names_map = OrderedDict((sheet_name, sheet_name) for sheet_name in self.workbook.get_sheet_names())
+        self.sheet_names_map = OrderedDict((sheet_name, sheet_name) for sheet_name in self.workbook.sheetnames)
         if self.include_sheets:
             for sheet in list(self.sheet_names_map):
                 if sheet not in self.include_sheets:

--- a/flattentool/tests/test_output.py
+++ b/flattentool/tests/test_output.py
@@ -32,7 +32,7 @@ def test_blank_sheets(tmpdir):
 
     # Check XLSX is empty
     wb = openpyxl.load_workbook(tmpdir.join('release.xlsx').strpath)
-    assert wb.get_sheet_names() == ['release']
+    assert wb.sheetnames == ['release']
     rows = list(wb['release'].rows)
     assert len(rows) == 1
     assert len(rows[0]) == 1
@@ -55,7 +55,7 @@ def test_populated_header(tmpdir):
 
     # Check XLSX
     wb = openpyxl.load_workbook(tmpdir.join('release.xlsx').strpath)
-    assert wb.get_sheet_names() == ['release', 'b']
+    assert wb.sheetnames == ['release', 'b']
     rows = list(wb['release'].rows)
     assert len(rows) == 1
     assert [ x.value for x in rows[0] ] == [ 'a', 'd' ]
@@ -86,7 +86,7 @@ def test_empty_lines(tmpdir):
 
     # Check XLSX
     wb = openpyxl.load_workbook(tmpdir.join('release.xlsx').strpath)
-    assert wb.get_sheet_names() == ['release', 'b']
+    assert wb.sheetnames == ['release', 'b']
     rows = list(wb['release'].rows)
     assert len(rows) == 1
     assert [ x.value for x in rows[0] ] == [ 'a', 'd' ]
@@ -119,7 +119,7 @@ def test_populated_lines(tmpdir):
 
     # Check XLSX
     wb = openpyxl.load_workbook(tmpdir.join('release.xlsx').strpath)
-    assert wb.get_sheet_names() == ['release', 'b']
+    assert wb.sheetnames == ['release', 'b']
     rows = list(wb['release'].rows)
     assert len(rows) == 3
     assert [ x.value for x in rows[0] ] == [ 'a' ]
@@ -152,7 +152,7 @@ def test_utf8(tmpdir):
 
     # Check XLSX
     wb = openpyxl.load_workbook(tmpdir.join('release.xlsx').strpath)
-    assert wb.get_sheet_names() == ['release']
+    assert wb.sheetnames == ['release']
     rows = list(wb['release'].rows)
     assert len(rows) == 3
     assert [ x.value for x in rows[0] ] == [ 'é' ]


### PR DESCRIPTION
@BibianaC This should make the datagetter a lot less noisy, so it's easier to see the stuff that matters.