### PR TITLE
[COMPLETE] Fix XML unflattening with stdlib etree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Avoid some openpyxl warnings https://github.com/OpenDataServices/flatten-tool/pull/211
+- Fix XML unflattening with stdlib etree https://github.com/OpenDataServices/flatten-tool/pull/212
 
 ## [0.1.2] - 2018-06-28
 

--- a/flattentool/xml_output.py
+++ b/flattentool/xml_output.py
@@ -81,5 +81,4 @@ def toxml(data, xml_root_tag):
     if USING_LXML:
         return ET.tostring(root, pretty_print=True)
     else:
-        indent(root)
         return ET.tostring(root)


### PR DESCRIPTION
This would ideally be merged before #196, since that includes this change.

---

The `indent` function (required for pretty printing with stdlib etree) isn’t included, so calling it results in an error. This PR removes that call, so XML unflattening without lxml will (probably) work.

Fix was originally made by @Bjwebb in 8998e3af3f75e500179fc4cfec0d10ecbf53c742.