### PR TITLE
Install the latest six, to avoid errors on upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.6"
 # Apparently six must be installed first, otherwise setup.py will be unhappy
 install:
-  - pip install six
+  - pip install --upgrade six
   - pip install --upgrade -r requirements_dev.txt
 script: py.test --cov .
 after_success: coveralls


### PR DESCRIPTION
I think this should fix our intermittent Python 3.4 failures. I think
six is required for the pip install, so upgrading (which removes and
then installs a new copy) causes problems. We can avoid the upgrade by
installing the latest six beforehand.