### PR TITLE
[WIP] Prefer RootListPath from sheet configuration over CLI/function argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Prefer `RootListPath` from sheet configuration over CLI/function argument https://github.com/OpenDataServices/flatten-tool/pull/214
+
 ## [0.2.0] - 2018-08-13
 
 ### Added

--- a/flattentool/__init__.py
+++ b/flattentool/__init__.py
@@ -111,7 +111,7 @@ def decimal_default(o):
 
 
 def unflatten(input_name, base_json=None, input_format=None, output_name=None,
-              root_list_path=None, encoding='utf8', timezone_name='UTC',
+              root_list_path='main', encoding='utf8', timezone_name='UTC',
               root_id=None, schema='', convert_titles=False, cell_source_map=None,
               heading_source_map=None, id_name='id', xml=False,
               vertical_orientation=False,
@@ -180,8 +180,7 @@ def unflatten(input_name, base_json=None, input_format=None, output_name=None,
         if result:
             base.update(result[0])
 
-    if root_list_path is None:
-        root_list_path = base_configuration.get('RootListPath', 'main')
+    root_list_path = base_configuration.get('RootListPath', root_list_path)
 
     if not metatab_only:
         spreadsheet_input_class = INPUT_FORMATS[input_format]


### PR DESCRIPTION
This means that we can call flatten-tool from CoVE with `root_list_path='iati-activity'`, so that this is the default, but then override this in a spreadsheet e.g. with `RootListPath iati-organisation`
