### PR TITLE
WIP: Add --no-root-list-path to unflatten

### DIFF
--- a/flattentool/__init__.py
+++ b/flattentool/__init__.py
@@ -111,7 +111,7 @@ def decimal_default(o):
 
 
 def unflatten(input_name, base_json=None, input_format=None, output_name=None,
-              root_list_path=None, encoding='utf8', timezone_name='UTC',
+              root_list_path=None, no_root_list_path=False, encoding='utf8', timezone_name='UTC',
               root_id=None, schema='', convert_titles=False, cell_source_map=None,
               heading_source_map=None, id_name=None, xml=False,
               vertical_orientation=False,
@@ -131,7 +131,9 @@ def unflatten(input_name, base_json=None, input_format=None, output_name=None,
     if metatab_name and base_json:
         raise Exception('Not allowed to use base_json with metatab')
 
-    if base_json:
+    if no_root_list_path:
+        base = None
+    elif base_json:
         with open(base_json) as fp:
             base = json.load(fp, object_pairs_hook=OrderedDict)
     else:
@@ -145,7 +147,7 @@ def unflatten(input_name, base_json=None, input_format=None, output_name=None,
     cell_source_map_data = OrderedDict()
     heading_source_map_data = OrderedDict()
 
-    if metatab_name:
+    if metatab_name and not no_root_list_path:
         spreadsheet_input_class = INPUT_FORMATS[input_format]
         spreadsheet_input = spreadsheet_input_class(
             input_name=input_name,
@@ -211,7 +213,10 @@ def unflatten(input_name, base_json=None, input_format=None, output_name=None,
         )
         cell_source_map_data.update(cell_source_map_data_main or {})
         heading_source_map_data.update(heading_source_map_data_main or {})
-        base[root_list_path] = list(result)
+        if no_root_list_path:
+            base = list(result)
+        else:
+            base[root_list_path] = list(result)
 
     if xml:
         xml_root_tag = base_configuration.get('XMLRootTag', 'iati-activities')

--- a/flattentool/cli.py
+++ b/flattentool/cli.py
@@ -128,6 +128,10 @@ def create_parser():
         "-m", "--root-list-path",
         help="The path in the JSON that will contain the unflattened list. Defaults to main.")
     parser_unflatten.add_argument(
+        "-n", "--no-root-list-path",
+        action='store_true',
+        help="The JSON is only an unflattened list.")
+    parser_unflatten.add_argument(
         "-e", "--encoding",
         help="Encoding of the input file(s) (only relevant for CSV). This can be any encoding recognised by Python. Defaults to utf8.")
     parser_unflatten.add_argument(


### PR DESCRIPTION
This is needed for Open Ownership data. It's just a list: http://standard.openownership.org/en/schema-beta-2/examples/index.html  

Take this input CSV:
```
statementID,statementType,identifiers/0/scheme,identifiers/0/id
e3c07f34-1810-4eed-b845-4d9f4d97f9d5,entityStatement,GB-COH,07444723
e3c07f34-1810-4eed-b845-4d9f4d97f9d6,entityStatement,GB-COH,07444724
```

Run:

    flatten-tool unflatten -f csv examples/bods-one/  -o examples/bods-one.json

And you get: 

```
{
    "main": [
        {
            "statementID": "e3c07f34-1810-4eed-b845-4d9f4d97f9d5",
            "statementType": "entityStatement",
            "identifiers": [
                {
                    "scheme": "GB-COH",
                    "id": "07444723"
                }
            ]
        },
        {
            "statementID": "e3c07f34-1810-4eed-b845-4d9f4d97f9d6",
            "statementType": "entityStatement",
            "identifiers": [
                {
                    "scheme": "GB-COH",
                    "id": "07444724"
                }
            ]
        }
    ]
}
```

This is not valid Open Ownership data. The problem here is the "main" key. The tool currently has options to get change "main" to something else, but - as far as I can tell - no option to remove it entirely??

This P.R. adds that. Now if you run:

    flatten-tool unflatten -f csv examples/bods-one/  -o examples/bods-one.json --no-root-list-path

You get:

```
[
    {
        "statementID": "e3c07f34-1810-4eed-b845-4d9f4d97f9d5",
        "statementType": "entityStatement",
        "identifiers": [
            {
                "scheme": "GB-COH",
                "id": "07444723"
            }
        ]
    },
    {
        "statementID": "e3c07f34-1810-4eed-b845-4d9f4d97f9d6",
        "statementType": "entityStatement",
        "identifiers": [
            {
                "scheme": "GB-COH",
                "id": "07444724"
            }
        ]
    }
]
```
Which is correct!

This is work in progress 'cos:
  *  need to update docs and changelog
  *  need to test more
  *  need to think about what other options (eg metatab, base_json) no longer will work when this is enabled, make sure they are disabled in that case only, test, document
  *  add a automatic test?
