### PR TITLE
WIP Add --no-root-list-path to flatten

### DIFF
--- a/flattentool/__init__.py
+++ b/flattentool/__init__.py
@@ -43,7 +43,8 @@ def create_template(schema, output_name='template', output_format='all', main_sh
 
 
 def flatten(input_name, schema=None, output_name='flattened', output_format='all', main_sheet_name='main',
-            root_list_path='main', rollup=False, root_id=None, use_titles=False, xml=False, id_name='id',  **_):
+            no_root_list_path=False, root_list_path='main',
+            rollup=False, root_id=None, use_titles=False, xml=False, id_name='id',  **_):
     """
     Flatten a nested structure (JSON) to a flat structure (spreadsheet - csv or xlsx).
 
@@ -60,7 +61,7 @@ def flatten(input_name, schema=None, output_name='flattened', output_format='all
         schema_parser = None
     parser = JSONParser(
         json_filename=input_name,
-        root_list_path=root_list_path,
+        root_list_path=None if no_root_list_path else root_list_path,
         schema_parser=schema_parser,
         root_id=root_id,
         use_titles=use_titles,

--- a/flattentool/cli.py
+++ b/flattentool/cli.py
@@ -92,6 +92,10 @@ def create_parser():
         "--root-list-path",
         help="Path of the root list, defaults to main")
     parser_flatten.add_argument(
+        "--no-root-list-path",
+        action='store_true',
+        help="No root list path")
+    parser_flatten.add_argument(
         "--rollup",
         action='store_true',
         help="\"Roll up\" columns from subsheets into the main sheet if they are specified in a rollUp attribute in the schema.")


### PR DESCRIPTION
Very similar to #221, this one will be .....

This is needed for Open Ownership data. It's just a list: http://standard.openownership.org/en/schema-beta-2/examples/index.html

Take this input JSON:

```
[
  {
    "statementID": "1dc0e987-5c57-4a1c-b3ad-61353b66a9b7",
    "statementType": "entityStatement",
    "statementDate": "2017-11-18",
    "entityType": "registeredEntity",
    "name": "CHRINON LTD",
    "foundingDate": "2010-11-18",
    "identifiers": [
      {
        "scheme": "GB-COH",
        "id": "07444723"
      }
    ]
  }
]
```

Try and run flatten, and it'll crash.

```
(.ve) vagrant@ubuntu-xenial:/vagrant/flatten-tool$ flatten-tool flatten -f csv examples/bods-one.json  -o examples/bods-one-flatten  --id-name="statementID"
Traceback (most recent call last):
  File "/vagrant/flatten-tool/.ve/bin/flatten-tool", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/vagrant/flatten-tool/flatten-tool", line 3, in <module>
    flattentool.cli.main()
  File "/vagrant/flatten-tool/flattentool/cli.py", line 222, in main
    flatten(**kwargs_from_parsed_args(args))
  File "/vagrant/flatten-tool/flattentool/__init__.py", line 70, in flatten
    parser.parse()
  File "/vagrant/flatten-tool/flattentool/json_input.py", line 98, in parse
    root_json_list = path_search(self.root_json_dict, self.root_list_path.split('/'))
  File "/vagrant/flatten-tool/flattentool/input.py", line 801, in path_search
    nested_dict[parent_field] = OrderedDict()
TypeError: list indices must be integers or slices, not str
```

Add --no-root-list-path as a new option! Oddly enough this was really easy - the class can already work with this IF it's passed None as an option - it's just the CLI was incapable of passing None! So added that.

Now:

    flatten-tool flatten -f csv examples/bods-one.json  -o examples/bods-one-flatten  --no-root-list-path --id-name="statementID"

Will make main.csv:

```
statementID,statementType,statementDate,entityType,name,foundingDate
1dc0e987-5c57-4a1c-b3ad-61353b66a9b7,entityStatement,2017-11-18,registeredEntity,CHRINON LTD,2010-11-18
```

And identifiers.csv:

```
statementID,identifiers/0/scheme,identifiers/0/id
1dc0e987-5c57-4a1c-b3ad-61353b66a9b7,GB-COH,07444723
```

This is work in progress 'cos:

  *    need to update docs and changelog
  *   need to test more
  *   do any other options no longer will work when this is enabled, in which case make sure they are disabled in that case only, test, document
  *   add a automatic test?
