### PR TITLE
setup.py & requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
--r requirements.txt
+-e .[HTTP]
+urllib3==1.23
 pytest
 pytest-cov
 coveralls

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license='MIT',
     description='Tools for generating CSV and other flat versions of the structured data',
     install_requires=install_requires,
-    extras_requires = {
+    extras_require = {
         'HTTP': ['requests']
     }
 )


### PR DESCRIPTION
Fix extra requirements in setup.py
In requirements_dev.txt, make sure you install the lib with all extras
Also in requirements_dev.txt, lock to a version of urllib3 that we know works with requests