### PR TITLE
Fix backticks in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Ignore elements that don't exist in the schema, whilst sorting xml. Previously an exception was raised. https://github.com/OpenDataServices/flatten-tool/pull/218
+- Ignore elements that don't exist in the schema, whilst sorting XML. Previously an exception was raised. https://github.com/OpenDataServices/flatten-tool/pull/218
 - Fix: unflatten would crash if given a csv with an empty first row https://github.com/OpenDataServices/flatten-tool/pull/229
 - Clarified meaning of headerrows in docs. https://github.com/OpenDataServices/flatten-tool/issues/230
-- Tool can work with schema's that have refs to local files (part of https://github.com/OpenDataServices/flatten-tool/issues/225 )
-- Schema loader can work with schema's that have 'oneOf' (part of https://github.com/OpenDataServices/flatten-tool/issues/225 )
+- Tool can work with schemas that have refs to local files (part of https://github.com/OpenDataServices/flatten-tool/issues/225 )
+- Schema loader can work with schemas that have 'oneOf' (part of https://github.com/OpenDataServices/flatten-tool/issues/225 )
 
 ## [0.2.0] - 2018-08-13
 
@@ -57,8 +57,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Add missing comma to CSV fixture https://github.com/OpenDataServices/flatten-tool/pull/203
-- Do not hardcode iati-activities for top level for all xml https://github.com/OpenDataServices/flatten-tool/issues/150
-- Don't split text value of xml array https://github.com/OpenDataServices/flatten-tool/pull/208
+- Do not hard code iati-activities for top level for all XML https://github.com/OpenDataServices/flatten-tool/issues/150
+- Don't split text value of XML array https://github.com/OpenDataServices/flatten-tool/pull/208
 
 ## [0.1.1] - 2018-03-28
 

--- a/docs/create-template.rst
+++ b/docs/create-template.rst
@@ -7,27 +7,27 @@ spreadsheet and producing a JSON document.
 If you already have a JSON schema, Flatten Tool can automatically create a
 template spreadsheet with the correct headers that you can start filling in.
 
-Flatten Tool's sub-command for this is `flatten-tool create-template`.
+Flatten Tool's sub-command for this is ``flatten-tool create-template``.
 
 
 Generating a spreadsheet template from a JSON Schema
 ====================================================
 
-Here's an example command that uses a schema from the cafe example under `Sheet
-shapes` and generates a spreadsheet:
+Here's an example command that uses a schema from the cafe example under
+:doc:`Sheet shapes <unflatten#sheet-shapes>` and generates a spreadsheet:
 
 .. literalinclude:: ../examples/create-template/simple/cmd.txt
    :language: bash
 
-The example uses `--use-titles` so that the generated spreadsheet has human
-readable titles and `--main-sheet-name=cafe` so that the generated spreadsheet
-have `cafe` as their first tab and not the default, `main`.
+The example uses ``--use-titles`` so that the generated spreadsheet has human
+readable titles and ``--main-sheet-name=cafe`` so that the generated spreadsheet
+has ``cafe`` as its first tab and not the default, ``main``.
 
-If you don't specify `-o`, Flatten Tool will choose a spreadsheet called
-`template` in the current working directory.
+If you don't specify ``-o``, Flatten Tool will choose a spreadsheet called
+``template`` in the current working directory.
 
-If you don't specify a format with `-f`, Flatten Tool will create a
-`template.xlsx` file and a set of CSV files under `template/`.
+If you don't specify a format with ``-f``, Flatten Tool will create a
+``template.xlsx`` file and a set of CSV files under ``template/``.
 
 The schema is the same as the one used in the user guide and looks like this:
 
@@ -61,9 +61,9 @@ have the values listed on the main sheet.
 
 To enable roll up behaviour you have to:
 
-* Use the `--rollup` flag
+* Use the ``--rollup`` flag
 
-* Add the `rollUp` key to the JSON Schema to the child object with a value that
+* Add the ``rollUp`` key to the JSON Schema to the child object with a value that
   is an array of the fields to roll up
 
 Here are the changes we make to the schema:
@@ -88,7 +88,7 @@ Here are the resulting sheets:
    :file: ../examples/create-template/rollup/expected/tab_dish.csv
 
 
-Notice how `Table: Number` has now been moved into the `cafe.csv` file.
+Notice how ``Table: Number`` has now been moved into the ``cafe.csv`` file.
 
 .. caution ::
 
@@ -111,7 +111,7 @@ object so that you can still add columns at a later date.
 Disable local refs
 ------------------
 
-You can pass a `--disable-local-refs` flag for a special mode that will disable local refs in JSON Schema files.
+You can pass a ``--disable-local-refs`` flag for a special mode that will disable local refs in JSON Schema files.
 
 .. literalinclude:: ../examples/create-template/refs-disable-local-refs/cmd.txt
    :language: bash

--- a/docs/developerguide.rst
+++ b/docs/developerguide.rst
@@ -29,7 +29,7 @@ Helper libraries
 
 As you'll have read in the :doc:`User Guide <unflatten>`, Flatten Tool makes
 use of JSON Pointer, JSON Schema and JSON Ref standards. The Python libraries
-that support this are `jsonpointer`, `jsonschema` and `jsonref` respectively.
+that support this are ``jsonpointer``, ``jsonschema`` and ``jsonref`` respectively.
 
 
 Running the tests
@@ -68,7 +68,7 @@ Spreadsheet Loaders
 
    Responsible for loading data out of spreadsheets and representing it in the
    correct format for the unflattener - a Python structure of basic JSON types and
-   the special `Empty` value
+   the special ``Empty`` value
 
 Unflatten function
 
@@ -81,8 +81,8 @@ Unflatten function
 
    .. tip ::
 
-      Take a look at the `run()` function in
-      `flattentool/tests/test_headings.py` to see a function that behaves a
+      Take a look at the ``run()`` function in
+      ``flattentool/tests/test_headings.py`` to see a function that behaves a
       little like a pure Python entry point to Flatten Tool's functionality.
 
 Serialisers
@@ -101,10 +101,10 @@ The existing implementation makes a special effort to correctly handle decimal
 types such as currency.
 
 This special effort also means that Flatten Tool treats float values as
-`Decimal` too.
+``Decimal`` too.
 
 Most of the time this is perfectly fine, since Python correctly treats a
-`Decimal` generated from a float as being equal to the float itself:
+``Decimal`` generated from a float as being equal to the float itself:
 
 .. code-block:: python
 
@@ -113,8 +113,8 @@ Most of the time this is perfectly fine, since Python correctly treats a
    True
 
 Do be aware of this small quirk of Python's behaviour though. Python doesn't
-treat a `Decimal` obtained from `'1.3'` as being the same as one generated from
-`1.3`:
+treat a ``Decimal`` obtained from ``'1.3'`` as being the same as one generated from
+``1.3``:
 
 .. code-block:: python
 
@@ -126,7 +126,7 @@ treat a `Decimal` obtained from `'1.3'` as being the same as one generated from
 Stdin support
 -------------
 
-The next version could support a single sheet being fed into `stdin` like this:
+The next version could support a single sheet being fed into ``stdin`` like this:
 
 .. code-block:: bash
 
@@ -147,16 +147,16 @@ Naming and Versioning
 ---------------------
 
 The next release of Flatten Tool will likely start a version numbering schema.
-We could also name the command line tool `flattentool` rather than
-`flatten-tool` so that everything is consistent.
+We could also name the command line tool ``flattentool`` rather than
+``flatten-tool`` so that everything is consistent.
 
 Other possible directions
 -------------------------
 
-It might be also be good to add a `CHANGELOG.txt` which could document changes
+It might be also be good to add a ``CHANGELOG.txt`` which could document changes
 such as:
 
 * This documentation
 * Changed stdout behaviour for unflatten and loss of the default - writing to
-  `unflattened.json`.
+  ``unflattened.json``.
 * Publishing on PyPi

--- a/docs/developerguide.rst
+++ b/docs/developerguide.rst
@@ -37,10 +37,10 @@ Running the tests
 
 After following the installation above, run ``py.test``.
 
-Note that the tests require the Python testsuite. This should come with python,
-but some distros split it out. On Ubuntu you will need to install a package
-like ``libpython3.4-testsuite`` (depending on which Python version you are
-using).
+Note that the tests require the Python test suite. This should come with Python,
+but some distributions split it out. On Ubuntu you will need to install a
+package like ``libpython3.4-testsuite`` (depending on which Python version you
+are using).
 
 
 
@@ -76,7 +76,7 @@ Unflatten function
    JSON Schema if present and keeping all state explicit.
 
    Use the JSON Schema to convert any basic JSON types to richer types that can
-   be correctly serailised by a serialiser later (e.g. dates). Returns a cell
+   be correctly serialised by a serialiser later (e.g. dates). Returns a cell
    tree.
 
    .. tip ::

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -41,7 +41,7 @@ We can use these Spreadsheets:
    :file: ../examples/array_multisheet/main.csv
    :header-rows: 1
 
-These are also the spreadsheets that flatten-tool's `flatten` (JSON to Spreadsheet) will produce.
+These are also the spreadsheets that flatten-tool's ``flatten`` (JSON to Spreadsheet) will produce.
 
 Commands used to generate this:
 

--- a/docs/flatten.rst
+++ b/docs/flatten.rst
@@ -14,7 +14,7 @@ In this section you'll learn about flattening. The main use case for wanting to
 flatten a JSON document is so that you can manage the data in a spreadsheet
 from now on.
 
-Flatten Tool provides `flatten-tool flatten` sub-command for this purpose.
+Flatten Tool provides ``flatten-tool flatten`` sub-command for this purpose.
 
 
 Generating a spreadsheet from a JSON document
@@ -26,8 +26,8 @@ template.
 .. literalinclude:: ../examples/flatten/simple/cmd.txt
    :language: bash
 
-One difference is that the default output name is `flatten`, and so the command
-above will generate a `flatten/` directory with CSV files and a `flatten.xlsx`
+One difference is that the default output name is ``flatten``, and so the command
+above will generate a ``flatten/`` directory with CSV files and a ``flatten.xlsx``
 file in the current working directory.
 
 The schema is the same as the one used in the user guide and looks like this:
@@ -45,7 +45,7 @@ CSV files for you, populated with the data from the input JSON file.
 
 .. warning ::
 
-   You can't use `--use-titles` with flatten.
+   You can't use ``--use-titles`` with flatten.
 
 .. csv-table:: sheet: cafe.csv
    :file: ../examples/flatten/simple/expected/cafe.csv
@@ -60,12 +60,12 @@ CSV files for you, populated with the data from the input JSON file.
 
 .. caution ::
 
-   If you forget the `--root-list-path` option and your data isn't under a top
-   level key called `main`, Flatten Tool won't find your data and will instead
-   generate empty a single empty sheet called `main`, which probably isn't what
+   If you forget the ``--root-list-path`` option and your data isn't under a top
+   level key called ``main``, Flatten Tool won't find your data and will instead
+   generate empty a single empty sheet called ``main``, which probably isn't what
    you want.
 
-If your data has a list as a root, use the `--root-is-list` option.
+If your data has a list as a root, use the ``--root-is-list`` option.
 
 .. literalinclude:: ../examples/flatten/root-is-list/data.json
    :language: json
@@ -103,7 +103,7 @@ Filter
 
 When flattening, you can optionally choose to only process some of the data.
 
-Currently, only simple filters can be specified using the `--filter-field` and `--filter-value` option.
+Currently, only simple filters can be specified using the ``--filter-field`` and ``--filter-value`` option.
 
 .. literalinclude:: ../examples/flatten/filter/input.json
    :language: json
@@ -119,9 +119,9 @@ Currently, only simple filters can be specified using the `--filter-field` and `
    :file: ../examples/flatten/filter/expected/pints.csv
    :header-rows: 1
 
-No `dishes` sheet is produced, and the main sheet does not have a `coffee` column.
+No ``dishes`` sheet is produced, and the main sheet does not have a ``coffee`` column.
 
-The field specified must be a field directly on the data object - it's not possible to filter on fields like `pints/0/title` .
+The field specified must be a field directly on the data object - it's not possible to filter on fields like ``pints/0/title`` .
 
 All flatten options
 -------------------

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -25,13 +25,13 @@ will print general help information.
 
     flatten-tool {create-template,flatten,unflatten} -h
 
-will print help information specific to that subcommand.
+will print help information specific to that sub-command.
 
 Python Version Support
 ----------------------
 
 This code supports Python 2.7 and Python 3.3 (and later). Python 3 is
-strongly preferred. Only servere Python 2 specific bugs will be fixed, see the
+strongly preferred. Only severe Python 2 specific bugs will be fixed, see the
 `python2-wontfix <https://github.com/OpenDataServices/flatten-tool/issues?q=is%3Aissue+label%3Apython2-wontfix+is%3Aclosed>`_
 label on GitHub for known minor issues.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,7 @@ Contents:
    usage-bods
 
 Get started by reading the Spreadsheet Designer's Guide to understand the core
-concepts, how to use the `flatten-tool` command and how to structure your own
+concepts, how to use the ``flatten-tool`` command and how to structure your own
 data as spreadsheet sheets.
 
 The Developer Guide (work in progress) will go into more detail about how

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -12,14 +12,14 @@ But, consider two audiences for this dataset:
 
 **The analyst** needs flat data - tables that can be sorted, filtered and explored in a spreadsheet. 
 
-Which format should the data be published in? Flattten-Tool thinks it should be both. 
+Which format should the data be published in? Flatten Tool thinks it should be both. 
 
-By introducing a couple of simple rules, Flatten-Tool is aiming to allow data to be round-tripped between JSON and flat formats, sticking to sensible idioms in both flat-land and a structured world. 
+By introducing a couple of simple rules, Flatten Tool is aiming to allow data to be round-tripped between JSON and flat formats, sticking to sensible idioms in both flat-land and a structured world. 
 
 How 
 ---
 
-Flatten-Tool was designed to work along with a JSON Schema. Flatten-Tool likes
+Flatten Tool was designed to work along with a JSON Schema. Flatten Tool likes
 JSON Schemas which:
 
 **(1) Provide an "id" at every level of the structure**
@@ -31,7 +31,7 @@ version. It turns out this is also pretty useful for JSON-LD mapping.
 
 Often in a data structure, there are only a few properties that exist at the
 root level, with most properties at least one level deep in the structure.
-However, if Flatten-Tool hides away all the important properties in sub tables,
+However, if Flatten Tool hides away all the important properties in sub tables,
 then the spreadsheet user has to hunt all over the place for the properties
 that matter to them.
 
@@ -47,7 +47,7 @@ a single table.
 **(3) Provide unique field titles**
 
 "Recipient Org: Name" is a lot friendlier to spreadsheet users than
-'receipientOrganisation/name'. So, Flatten-Tool includes support for using the
+'recipientOrganization/name'. So, Flatten Tool includes support for using the
 titles of JSON fields instead of the field names when creating a spreadsheet
 template and converting data.
 
@@ -56,7 +56,7 @@ unique.
 
 **(4) Don't nest too deep**
 
-Whilst Flatten-Tool can cope with multiple laters of nesting in a data
+Whilst Flatten Tool can cope with multiple layers of nesting in a data
 structure, the deeper the structure gets, the trickier it is for the
 spreadsheet user to understand what is going on. So, we try and just go a few
-layers deep at most in data for Flatten-Tool to work with. 
+layers deep at most in data for Flatten Tool to work with. 

--- a/docs/unflatten.rst
+++ b/docs/unflatten.rst
@@ -37,13 +37,13 @@ Let's try converting the sheet to the JSON above.
    :language: json
 
 That's not too far off what we wanted. You can see the array of cafes, but the
-key is named `main` instead of `cafe`.  You can tell Flatten Tool that that the
-rows in the spreadsheet are cafes and should come under a `cafe` key by
+key is named ``main`` instead of ``cafe``.  You can tell Flatten Tool that that the
+rows in the spreadsheet are cafes and should come under a ``cafe`` key by
 specifying a *root list path*, described next.
 
 .. caution::
 
-   Older Python versions add a trailing space after `,` characters when
+   Older Python versions add a trailing space after ``,`` characters when
    outputting indented JSON. This means that your output might have whitespace
    differences compared to what is described here.
 
@@ -53,10 +53,10 @@ Root List Path
 The *root list path* is the key under which Flatten Tool should add an array of
 objects representing each row of the main sheet.
 
-You specify the root list path with `--root-list-path` option. If you don't
-specify it, `main` is used as the default as you saw in the last example.
+You specify the root list path with ``--root-list-path`` option. If you don't
+specify it, ``main`` is used as the default as you saw in the last example.
 
-Let's set `--root-list-path` to `cafe` so that our original input generates the
+Let's set ``--root-list-path`` to ``cafe`` so that our original input generates the
 JSON we were expecting:
 
 .. literalinclude:: ../examples/cafe/simple/cmd.txt
@@ -68,14 +68,14 @@ That's what we expected. Great.
 
 .. note::
 
-    Although `--root-list-path` sounds like it accepts a path such as
-    `building/cafe`, it only accepts a single key.
+    Although ``--root-list-path`` sounds like it accepts a path such as
+    ``building/cafe``, it only accepts a single key.
 
 
 The Root is a list
 ------------------
 
-You can also specify the data outputted is just a list, using the `--root-is-list` option.
+You can also specify the data outputted is just a list, using the ``--root-is-list`` option.
 
 .. literalinclude:: ../examples/cafe/root-is-list/cmd.txt
    :language: bash
@@ -87,9 +87,9 @@ Writing output to a file
 ------------------------
 
 By default, Flatten Tool now prints its output to stdout. If you want it to
-write its output to a file instead, you can use the `-o` option.
+write its output to a file instead, you can use the ``-o`` option.
 
-Here's the same example, this time writing its output to `unflattened.json`:
+Here's the same example, this time writing its output to ``unflattened.json``:
 
 .. literalinclude:: ../examples/cafe/simple-file/cmd.txt
    :language: bash
@@ -104,7 +104,7 @@ If you want the resulting JSON to also include other keys that you know in
 advance, you can specify them in a separate *base JSON* file and Flatten Tool
 will merge the data from your spreadsheet into that file.
 
-For example, if `base.json` looks like this:
+For example, if ``base.json`` looks like this:
 
 .. literalinclude:: ../examples/cafe/simple-base-json/base.json
    :language: json
@@ -115,7 +115,7 @@ and the data looks like this:
    :file: ../examples/cafe/simple-base-json/data.csv
    :header-rows: 1
 
-you can run this command using the `--base-json` option to see the `base.json`
+you can run this command using the ``--base-json`` option to see the ``base.json``
 data with the with the spreadsheet rows merged in:
 
 .. literalinclude:: ../examples/cafe/simple-base-json/cmd.txt
@@ -125,7 +125,7 @@ data with the with the spreadsheet rows merged in:
 
 .. warning::
 
-   If you give the base JSON the same key as you specify in `--root-list-path`
+   If you give the base JSON the same key as you specify in ``--root-list-path``
    then Flatten Tool will overwrite its value.
 
 
@@ -145,7 +145,7 @@ use Flatten Tool:
 * OCDS - http://standard.open-contracting.org/validator/
 * 360Giving - http://www.threesixtygiving.org/standard/reference/
 
-Other options such as `--cell-source-map` and `--heading-source-map` will be
+Other options such as ``--cell-source-map`` and ``--heading-source-map`` will be
 described in the Developer Guide once the features stabilise.
 
 
@@ -171,18 +171,18 @@ spreadsheet lies in knowing about the `JSON Pointer specification
 <https://tools.ietf.org/html/rfc6901>`_.  This specification describes a fairly
 intuitive way to reference values in a JSON document.
 
-To briefly describe how it works, each `/` character after the first one drills
-down into a JSON structure. If they value after the `/` is a string, then a key
+To briefly describe how it works, each ``/`` character after the first one drills
+down into a JSON structure. If they value after the ``/`` is a string, then a key
 is looked up, if it is an integer then an array index is taken.
 
-For example, in the JSON pointer `/cafe/0/name` is equivalent to taking the
-following value out of a JSON document named `document`:
+For example, in the JSON pointer ``/cafe/0/name`` is equivalent to taking the
+following value out of a JSON document named ``document``:
 
 .. code-block:: python
 
     >>> document['cafe'][0]['name']
 
-In JSON document above, the JSON pointer `/cafe/0/name` would return `Healthy Cafe`.
+In JSON document above, the JSON pointer ``/cafe/0/name`` would return ``Healthy Cafe``.
 
 .. note::
 
@@ -203,7 +203,7 @@ You can think of Flatten Tool doing the following as it parses a sheet:
 * For each row:
 
    * Convert each column heading to a JSON pointer by removing whitespace and
-     prepending with `/cafe/`, then adding the row index and another `/` to the
+     prepending with ``/cafe/``, then adding the row index and another ``/`` to the
      front
 
    * Take the value in each column and associate it with the JSON pointer
@@ -214,8 +214,8 @@ You can think of Flatten Tool doing the following as it parses a sheet:
      JSON pointer, creating more structures as you go
 
 In this example there is only one sheet, and only one row, so when parsing that
-first row, `/cafe/0/` is appended to `name` to give the JSON pointer
-`/cafe/0/name`. Flatten Tool then writes `Healthy Cafe` in the correct position.
+first row, ``/cafe/0/`` is appended to ``name`` to give the JSON pointer
+``/cafe/0/name``. Flatten Tool then writes ``Healthy Cafe`` in the correct position.
 
 
 Index behaviour
@@ -226,11 +226,11 @@ There is one subtlety you need to be aware of though before you see some example
 Although Flatten Tool always uses strings in a JSON pointer as object keys, it
 only takes numbers it comes across as an *indication* of the array position.
 
-For example, if you gave it the JSON pointer `/cafe/1503/name`, there is no
-guarantee that the `name` would be placed in an object at index position 1503.
+For example, if you gave it the JSON pointer ``/cafe/1503/name``, there is no
+guarantee that the ``name`` would be placed in an object at index position 1503.
 
 Instead Flatten Tool uses numbers in the same sheet that are at the same parent
-JSON pointer path (`/cafe/` in this case), as being the sort order the child
+JSON pointer path (``/cafe/`` in this case), as being the sort order the child
 objects should appear in, but not the literal index positions.
 
 If two objects use the same index at the same base JSON pointer path, Flatten
@@ -250,7 +250,7 @@ IDs) later.
 
 .. tip::
 
-   You'll see later in the relationships section, that special `id` values can
+   You'll see later in the relationships section, that special ``id`` values can
    alter the index behavior described here and allow Flatten Tool to merge rows
    from multiple sheets.
 
@@ -264,18 +264,18 @@ Let's look at a multi-row example:
    :file: ../examples/cafe/simple-row/data.csv
    :header-rows: 1
 
-This time `Healthy Cafe` would be placed at `/cafe/0/name` and `Vegetarian
-Cafe` at `/cafe/1/name` producing this:
+This time ``Healthy Cafe`` would be placed at ``/cafe/0/name`` and ``Vegetarian
+Cafe`` at ``/cafe/1/name`` producing this:
 
 .. literalinclude:: ../examples/cafe/simple-row/cmd.txt
    :language: bash
 .. literalinclude:: ../examples/cafe/simple-row/expected.json
    :language: json
 
-Although both `Healthy Cafe` and `Vegetarian Cafe` are under a column that
-resolves to `/cafe/0/name`, the rules described in the previous section explain
-why both are present in the output and why `Healthy Cafe` comes before
-`Vegetarian Cafe`.
+Although both ``Healthy Cafe`` and ``Vegetarian Cafe`` are under a column that
+resolves to ``/cafe/0/name``, the rules described in the previous section explain
+why both are present in the output and why ``Healthy Cafe`` comes before
+``Vegetarian Cafe``.
 
 
 Multiple columns
@@ -289,13 +289,13 @@ Let's add the cafe address to the spreadsheet:
 
 .. note::
 
-   CSV files require cells containing `,` characters to be escaped by wrapping
+   CSV files require cells containing ``,`` characters to be escaped by wrapping
    them in double quotes. That's why if you look at the source CSV, the addresses
-   are escaped with `"` characters.
+   are escaped with ``"`` characters.
 
-This time `Healthy Cafe` is placed at `/cafe/0/name` as before, `London` is
-placed at `/cafe/0/address`. `Vegetarian Cafe` at `/cafe/1/name` as before and
-`Bristol` is at `/cafe/1/address`.
+This time ``Healthy Cafe`` is placed at ``/cafe/0/name`` as before, ``London`` is
+placed at ``/cafe/0/address``. ``Vegetarian Cafe`` at ``/cafe/1/name`` as before and
+``Bristol`` is at ``/cafe/1/address``.
 
 The result is:
 
@@ -331,7 +331,7 @@ Once all the sheets have been processed the resulting JSON is returned.
 
    This is why all the CSV file examples given so far have been written to a
    file in an empty directory and why only the directory name was needed in
-   the `flatten-tool` commands.
+   the ``flatten-tool`` commands.
 
 Here's a simple two-sheet example where the headings are the same in both
 sheets:
@@ -351,11 +351,11 @@ When you run the example you get this:
 .. literalinclude:: ../examples/cafe/multiple/expected.json
    :language: json
 
-The order is because the `data` sheet was processed before the `other` sheet.
+The order is because the ``data`` sheet was processed before the ``other`` sheet.
 
 .. tip::
 
-    CSV file sheets are processed in the order returned by `os.listdir()` so
+    CSV file sheets are processed in the order returned by ``os.listdir()`` so
     you should name them in the order you would like them processed.
 
 
@@ -373,8 +373,8 @@ object. For example, imagine you'd like out output JSON in this structure:
    :language: json
 
 You can do this by knowing that the JSON Pointer to "123 City Street" would be
-`/cafe/0/address/street` so that we would need to name the street column
-`address/street`.
+``/cafe/0/address/street`` so that we would need to name the street column
+``address/street``.
 
 Here's the data:
 
@@ -401,8 +401,8 @@ Each cafe has many tables, so this is an example of a one-to-many relationship
 if you are used to working with relational databases.
 
 You can represent the table information in JSON as a array of objects, where each
-object represents a table, and each table has a `number` key. Let's imagine the
-`Healthy Cafe` has three tables numbered 1, 2 and 3. We'd like to produce this
+object represents a table, and each table has a ``number`` key. Let's imagine the
+``Healthy Cafe`` has three tables numbered 1, 2 and 3. We'd like to produce this
 structure:
 
 .. literalinclude:: ../examples/cafe/list-of-objects/expected.json
@@ -453,7 +453,7 @@ re-order the columns so that table 3 comes first, then 2, then 1:
    :language: json
 
 Child objects like these tables can, of course have more than one key. Let's
-add a `reserved` key to table number 1 but to try to confuse Flatten Tool,
+add a ``reserved`` key to table number 1 but to try to confuse Flatten Tool,
 we'll specify it at the end:
 
 .. csv-table::
@@ -465,8 +465,8 @@ we'll specify it at the end:
 .. literalinclude:: ../examples/cafe/tables-index-reserved/expected.json
    :language: json
 
-Notice that Flatten Tool correctly associated the `reserved` key with table 1
-because of the index numbered `30`, even though the columns weren't next to
+Notice that Flatten Tool correctly associated the ``reserved`` key with table 1
+because of the index numbered ``30``, even though the columns weren't next to
 each other.
 
 For a much richer way of organising arrays of objects, see the Relationships
@@ -479,7 +479,7 @@ Plain Lists (Unsupported)
 Flatten Tool doesn't support arrays of JSON values other than objects (just
 described in the previous section).
 
-As a result heading names such as `tag/0` and `tag/1` would be ignored and an
+As a result heading names such as ``tag/0`` and ``tag/1`` would be ignored and an
 empty array would be put into the JSON.
 
 Here's some example data:
@@ -529,7 +529,7 @@ pass the cell value through to the JSON as a number in that case.
 
 .. note::
 
-    Make sure you specify the correct format `-f=xlsx` on the command line if
+    Make sure you specify the correct format ``-f=xlsx`` on the command line if
     you want to use an XLSX file.
 
 .. literalinclude:: ../examples/cafe/tables-typed-xlsx/cmd.txt
@@ -542,7 +542,7 @@ pass the cell value through to the JSON as a number in that case.
    Number formats in spreadsheets are ignored in Python 2.7 so this
    example won't work. It does work in Python 3.4 and above though.
 
-   If you look at Flatten Tool's source code you'll see the in `test_docs.py`
+   If you look at Flatten Tool's source code you'll see the in ``test_docs.py``
    that the above example is skipped on older Python versions.
 
 
@@ -575,7 +575,7 @@ Let's take a closer look at the array of objects example from earlier again:
    :file: ../examples/cafe/list-of-objects/data.csv
    :header-rows: 1
 
-The column headings `table/0/number`, `table/1/number` and `table/2/number`
+The column headings ``table/0/number``, ``table/1/number`` and ``table/2/number``
 aren't very human readable, wouldn't it be great if we could use headings like
 this:
 
@@ -586,9 +586,9 @@ this:
 Flatten Tool supports this if you do the following:
 
 * Write a JSON Schema specifying the titles being used and
-  specify it with the `--schema` option
-* Use `:` characters instead of `/` characters in the headings
-* Specify the `--convert-titles` option on the command line
+  specify it with the ``--schema`` option
+* Use ``:`` characters instead of ``/`` characters in the headings
+* Specify the ``--convert-titles`` option on the command line
 
 .. caution::
 
@@ -600,7 +600,7 @@ Here's a new JSON schema for this example:
 .. literalinclude:: ../examples/cafe/tables-human-1/cafe.schema
    :language: json
 
-Notice that both `Table` and `Number` are specified as titles.
+Notice that both ``Table`` and ``Number`` are specified as titles.
 
 Here's what we get when we run it:
 
@@ -613,7 +613,7 @@ Here's what we get when we run it:
 Optional array indexes
 ----------------------
 
-Looking at the JSON Schema from the last example again you'll see that `table`
+Looking at the JSON Schema from the last example again you'll see that ``table``
 is specified as an array type:
 
 .. literalinclude:: ../examples/cafe/tables-human-2/cafe.schema
@@ -622,7 +622,7 @@ is specified as an array type:
 This means that Flatten Tool can work out that any names specified in that
 column are part of that array. If you had an example with just one column
 representing each level of the tree, you could miss out the index in the
-heading when using `--schema` and `--convert-titles`.
+heading when using ``--schema`` and ``--convert-titles``.
 
 Here's a similar example, but with just one rolled up column:
 
@@ -649,8 +649,8 @@ In this section you'll learn how identifiers work and that will allow you much
 more freedom in designing different spreadsheet layouts that produce the same
 JSON.
 
-In Flatten Tool, any field named `id` is considered special. Flatten Tool knows
-that any objects with the same `id` at the same level are the same object and
+In Flatten Tool, any field named ``id`` is considered special. Flatten Tool knows
+that any objects with the same ``id`` at the same level are the same object and
 that their values should be merged.
 
 
@@ -662,14 +662,14 @@ The merge behaviour happens whether the two IDs are specified in:
 * different rows in the same sheet
 * two rows in two different sheets
 
-Basically, any time Flatten Tool comes across a row with an `id` in it, it will
-lookup any other objects in the array to see if that `id` is already used and if
+Basically, any time Flatten Tool comes across a row with an ``id`` in it, it will
+lookup any other objects in the array to see if that ``id`` is already used and if
 it is, it will merge it. If not, it will just append a new object to the array.
 
 .. caution::
 
-   It is important to make sure your `id` values really are unique. If you
-   accidentally use the same `id` for two different objects, Flatten Tool
+   It is important to make sure your ``id`` values really are unique. If you
+   accidentally use the same ``id`` for two different objects, Flatten Tool
    will think they are the same and merge them.
 
 
@@ -711,7 +711,7 @@ Notice the warnings above about values being over-written:
 
 .. literalinclude:: ../examples/cafe/relationship-merge-single/expected_stderr.json
 
-The actual JSON contains a single Cafe with `id` value `CAFE-HEALTH` and all
+The actual JSON contains a single Cafe with ``id`` value ``CAFE-HEALTH`` and all
 the values merged in:
 
 .. literalinclude:: ../examples/cafe/relationship-merge-single/expected.json
@@ -722,7 +722,7 @@ ID-based object merge in multiple sheets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Here's an example that uses the same data as the single sheet example above,
-but spreads the rows over four sheets named `a`, `b`, `c` and `d`:
+but spreads the rows over four sheets named ``a``, ``b``, ``c`` and ``d``:
 
 .. csv-table:: sheet: a
    :file: ../examples/cafe/relationship-merge-multiple/a.csv
@@ -761,11 +761,11 @@ Parent-child relationships (arrays of objects)
 ----------------------------------------------
 
 Things get much more interesting when you start dealing with arrays of objects
-whose parents have an `id`. This enables you to split the parents and children
+whose parents have an ``id``. This enables you to split the parents and children
 up into multiple sheets rather than requiring everything sits one the same row.
 
-As an example, let's imagine that `Vegetarian Cafe` is arranged having two
-tables numbered `16` and `17` because they are share tables with another
+As an example, let's imagine that ``Vegetarian Cafe`` is arranged having two
+tables numbered ``16`` and ``17`` because they are share tables with another
 restaurant next door.
 
 .. literalinclude:: ../examples/cafe/relationship-lists-of-objects-simple/expected.json
@@ -791,8 +791,8 @@ sheet:
    :header-rows: 1
 
 By having the tables in a separate sheet, you can now support cafe's with as
-many tables as you like, just by adding more rows and making sure the `id`
-column for the table matches the `id` value for the cafe.
+many tables as you like, just by adding more rows and making sure the ``id``
+column for the table matches the ``id`` value for the cafe.
 
 Let's run this example:
 
@@ -809,7 +809,7 @@ Index behaviour
 ---------------
 
 Within the array of tables for each cafe, you might have noticed that each table
-number has a JSON Pointer that ends in with `/0/number`. Since they all have the
+number has a JSON Pointer that ends in with ``/0/number``. Since they all have the
 same index, they are simply ordered within each cafe in the order of the rows
 in the sheet.
 
@@ -820,19 +820,19 @@ Grandchild relationships
 In future we might like to extend this example so that we can track the dishes
 ordered by each table so we can generate a bill.
 
-Let's take the case of dishes served at tables and imagine that `Healthy Cafe`
-has its own health `fish and chips` dish. Now let's also imagine that the dish
+Let's take the case of dishes served at tables and imagine that ``Healthy Cafe``
+has its own health ``fish and chips`` dish. Now let's also imagine that the dish
 is ordered at tables 1 and 3.
 
 If you are used to thinking about relational database you would probably think
-about having a new sheet called `dishes` with a two columns, one for an `id`
-and one for the `name` of the dish. You would then create a sheet to represent
-a join table called `table_dishes` that contained the ID of the table and of
+about having a new sheet called ``dishes`` with a two columns, one for an ``id``
+and one for the ``name`` of the dish. You would then create a sheet to represent
+a join table called ``table_dishes`` that contained the ID of the table and of
 the dish.
 
 The problem with this approach is that the output is actually a tree, and not a
 normalised relational model. Have a think about how you would write the
-`table_dishes` sheet. You'd need to write something like this:
+``table_dishes`` sheet. You'd need to write something like this:
 
 .. csv-table::
    :header-rows: 1
@@ -841,11 +841,11 @@ normalised relational model. Have a think about how you would write the
     TABLE-1,DISH-fish-and-chips
     TABLE-3,DISH-fish-and-chips
 
-The problem is that `dish/0/id` is really a JSON Pointer to `/cafe/0/dish/0/id`
-and so would try to create a new `dish` key under each *cafe*, not a `dish` key
+The problem is that ``dish/0/id`` is really a JSON Pointer to ``/cafe/0/dish/0/id``
+and so would try to create a new ``dish`` key under each *cafe*, not a ``dish`` key
 under each *table*.
 
-You can't do it this way. Instead you have to design you `dish` sheet to
+You can't do it this way. Instead you have to design you ``dish`` sheet to
 specify both the ID of the cafe and the ID of the table as well as the name of
 the dish. If a dish is used in multiple tables, you will have multiple rows,
 each with the same name in the name column. In this each way row contains the
@@ -873,9 +873,9 @@ Here are the results:
 .. literalinclude:: ../examples/cafe/relationship-multiple/expected.json
    :language: json
 
-Notice the ordering in this example. Because `dishes` is processed before
-`tables`, `TABLE-3` gets defined before `TABLE-2`, and `dish` gets added as a
-key before `tables`.
+Notice the ordering in this example. Because ``dishes`` is processed before
+``tables``, ``TABLE-3`` gets defined before ``TABLE-2``, and ``dish`` gets added as a
+key before ``tables``.
 
 If the sheets were processed the other way around the data would be the same,
 but the ordering different.
@@ -930,8 +930,8 @@ two cases where this can happen:
 
 To demonstrate both of these in one example consider the following example. In particular notice that:
 
-* `CAFE-VEG` is missing from the `cafes` sheet
-* `CAFE-VEG` is missing from the last row in the `tables` sheet
+* ``CAFE-VEG`` is missing from the ``cafes`` sheet
+* ``CAFE-VEG`` is missing from the last row in the ``tables`` sheet
 
 .. csv-table:: sheet: cafes
    :file: ../examples/cafe/relationship-missing-ids/cafes.csv
@@ -948,7 +948,7 @@ Let's run this example:
 .. literalinclude:: ../examples/cafe/relationship-missing-ids/expected.json
    :language: json
 
-You'll notice that all the data and tables for `CAFE-HEALTH` are output
+You'll notice that all the data and tables for ``CAFE-HEALTH`` are output
 correctly in the first object. This is what we'd expect because all the IDs
 were present.
 
@@ -981,12 +981,12 @@ Next is this cafe:
         },
 
 This is as much information as Flatten Tool can work out from the second row of
-the `cafes` sheet because the ID is missing. Flatten Tool just appends a new
+the ``cafes`` sheet because the ID is missing. Flatten Tool just appends a new
 cafe with the data it has.
 
-Next, Flatten Tool works through the `tables` sheet, it finds table 16 and
-knows it must be associated with a cafe called `CAFE-VEG` that is specified in
-the `id` column, but because this `id` is present in the `cafes` sheet, it
+Next, Flatten Tool works through the ``tables`` sheet, it finds table 16 and
+knows it must be associated with a cafe called ``CAFE-VEG`` that is specified in
+the ``id`` column, but because this ``id`` is present in the ``cafes`` sheet, it
 can't merge it in. Instead it just appends data for the cafe:
 
 .. code-block:: text
@@ -1000,7 +1000,7 @@ can't merge it in. Instead it just appends data for the cafe:
             ]
         },
 
-Finally, Flatten Tool finds table 17 in the `tables` sheet. It doesn't know
+Finally, Flatten Tool finds table 17 in the ``tables`` sheet. It doesn't know
 which Cafe this is for, but it knows tables are part of cafes so it adds
 another unnamed cafe:
 
@@ -1019,18 +1019,18 @@ Relationships with JSON Schema
 ------------------------------
 
 If you want to use Flatten Tool's support for JSON Schema to extend to relationships
-you need to amend your JSON Schema to tell it about the `id` fields:
+you need to amend your JSON Schema to tell it about the ``id`` fields:
 
-#. Make sure that the `id` field is specified for every object in the hierarchy
+#. Make sure that the ``id`` field is specified for every object in the hierarchy
    (although this isn't necessary for objects right at the bottom of the hierarchy)
 
-#. Give the `id` field a title of `Identifier`
+#. Give the ``id`` field a title of ``Identifier``
 
 With these two things in place, Flatten Tool will correctly handle relationships.
 
 .. caution::
 
-   If you forget to add the `id` field, Flatten Tool will not know anything
+   If you forget to add the ``id`` field, Flatten Tool will not know anything
    about it when generating templates or converting titles.
 
 
@@ -1222,15 +1222,15 @@ The command for doing this:
 Options
 -------
 
-`--metatab-name`
+``--metatab-name``
 
 This is the name of the sheet with the metadata on. It is case sensitive. It is the only mandatory option if you want to parse a metatab, without it no metatab will be parsed
 
-`--metatab-schema`
+``--metatab-schema``
 
 The JSON schema of the metatab. This schema will be used to determine the types and/or titles of the data in the metatab.  It works in the same way as the --schema option but just for the metatab.  The schema used with the --schema option has no effect on the metatab parsing, so this has to be specified if you need title handling or want to specify types.
 
-`--metatab-only`
+``--metatab-only``
 
 Just return the metatab information and not the rest of the doc. Using the example above:
 
@@ -1240,7 +1240,7 @@ Just return the metatab information and not the rest of the doc. Using the examp
 .. literalinclude:: ../examples/cafe/meta-tab-only/expected.json
    :language: json
 
-`--metatab-vertical-orientation`
+``--metatab-vertical-orientation``
 
 Say that the metatab data runs vertically rather that horizontally see example above.
 
@@ -1337,16 +1337,16 @@ A cell source map maps each JSON pointer in the document above back to the
 cells where that value is referenced.
 
 Using the example you've just seen, let's look at the very last value in the
-spreadsheet for the number of `TABLE-17` in `CAFE-VEG`. The JSON pointer is
-`cafe/1/table/1/number` and the value itself is `17`.
+spreadsheet for the number of ``TABLE-17`` in ``CAFE-VEG``. The JSON pointer is
+``cafe/1/table/1/number`` and the value itself is ``17``.
 
 Looking back at the source sheets you can see the only place this value appears
-is in `2_tables.csv`. It appears in column C (the third column), row 6 (row 1
+is in ``2_tables.csv``. It appears in column C (the third column), row 6 (row 1
 is treated as the heading so the values start at row 2). The heading of this
-column in `table/0/number` (which happens to be a JSON pointer, but if we were
+column in ``table/0/number`` (which happens to be a JSON pointer, but if we were
 using human readable headings, those headings would be used instead). We'd
 therefore expect the cell source map to have just one entry for
-`cafe/1/table/1/number` that points to cell `C2` like this:
+``cafe/1/table/1/number`` that points to cell ``C2`` like this:
 
 ::
 
@@ -1360,7 +1360,7 @@ therefore expect the cell source map to have just one entry for
     ],
 
 Here's the actual cell source map and as you can see, the entry for
-`cafe/1/table/1/number` is as we expect (it is near the end):
+``cafe/1/table/1/number`` is as we expect (it is near the end):
 
 .. literalinclude:: ../examples/receipt/source-map/expected/cell_source_map.json
    :language: json
@@ -1370,10 +1370,10 @@ happens when data appears in multiple places, such as when the cell refers to
 an identifier.
 
 You'll also notice that after all the JSON pointers that point to values such
-as `cafe/0/id` or `cafe/1/table/1/number` there are a set of JSON pointers that
-point to objects rather than cells. For example `cafe/0` or `cafe/1/table/1`.
+as ``cafe/0/id`` or ``cafe/1/table/1/number`` there are a set of JSON pointers that
+point to objects rather than cells. For example ``cafe/0`` or ``cafe/1/table/1``.
 These JSON pointers refer back to the rows which contain values that make up
-the object. For example `cafe/1/table/1` looks like this:
+the object. For example ``cafe/1/table/1`` looks like this:
 
 ::
 
@@ -1385,7 +1385,7 @@ the object. For example `cafe/1/table/1` looks like this:
     ]
 
 This tells us that the data that makes up that table in the final JSON was all
-defined in the `2_tables` sheet, row 6 (remembering that rows start at 2
+defined in the ``2_tables`` sheet, row 6 (remembering that rows start at 2
 because the header row is row 1). Again, if data from multiple rows goes to
 make up the object, there may be multiple arrays in the JSON pointer result.
 

--- a/docs/unflatten.rst
+++ b/docs/unflatten.rst
@@ -13,7 +13,7 @@ Before we get into too much detail though, let's start by looking
 at the Command Line API for unflattening a spreadsheet.
 
 
-Command-Line API
+Command Line API
 ================
 
 To demonstrate the command line API you'll start with the simplest possible
@@ -171,8 +171,8 @@ spreadsheet lies in knowing about the `JSON Pointer specification
 <https://tools.ietf.org/html/rfc6901>`_.  This specification describes a fairly
 intuitive way to reference values in a JSON document.
 
-To breifly describe how it works, each `/` character after the first one drills
-down into a JSON strucutre. If they value after the `/` is a string, then a key
+To briefly describe how it works, each `/` character after the first one drills
+down into a JSON structure. If they value after the `/` is a string, then a key
 is looked up, if it is an integer then an array index is taken.
 
 For example, in the JSON pointer `/cafe/0/name` is equivalent to taking the
@@ -274,7 +274,7 @@ Cafe` at `/cafe/1/name` producing this:
 
 Although both `Healthy Cafe` and `Vegetarian Cafe` are under a column that
 resolves to `/cafe/0/name`, the rules described in the previous section explain
-why noth are present in the output and why `Healthy Cafe` comes before
+why both are present in the output and why `Healthy Cafe` comes before
 `Vegetarian Cafe`.
 
 
@@ -523,14 +523,14 @@ Using spreadsheet cell formatting
 ---------------------------------
 
 CSV files only support string values, so the easiest way to get the example
-above to use integers would be to use a spreadsheet format such xlsx that
+above to use integers would be to use a spreadsheet format such as XLSX that
 supported integers and make sure the cell type was number. Flatten Tool would
 pass the cell value through to the JSON as a number in that case.
 
 .. note::
 
     Make sure you specify the correct format `-f=xlsx` on the command line if
-    you want to use an xlsx file.
+    you want to use an XLSX file.
 
 .. literalinclude:: ../examples/cafe/tables-typed-xlsx/cmd.txt
    :language: bash
@@ -1193,7 +1193,7 @@ table" section earlier.
 Metadata Tab
 ============
 
-Flattentool supports naming of a special sheetname (or Tab) in a spreadsheet to add data to the top level of the returned data structure.  Currently it only supports output format JSON and the input format has to be XLSX.
+Flatten Tool supports naming of a special sheet (or Tab) in a spreadsheet to add data to the top level of the returned data structure.  Currently it only supports output format JSON and the input format has to be XLSX.
 
 Example Usage
 -------------
@@ -1247,7 +1247,7 @@ Say that the metatab data runs vertically rather that horizontally see example a
 Configuration properties: skip and header rows
 ==============================================
 
-Flattentool supports directives in the first row of a file to tell it to:
+Flatten Tool supports directives in the first row of a file to tell it to:
 
 * **skiprows** - start processing data from n rows down
 * **headerrows** - the total number of header rows. Note that the first header row will be treated as field paths.
@@ -1263,7 +1263,7 @@ You have a CSV file named "mydata.csv" that contains:
 
 This pattern may occur, for example, when you export from a spreadsheet that includes formatted header rows that explain the data.
 
-By adding a row containing a cell with '#', and then a set of configuration directives, you can instruct flattentool to skip rows at the top of the file, and to recognise that the field paths are followed by a set of additional header lines. 
+By adding a row containing a cell with '#', and then a set of configuration directives, you can instruct Flatten Tool to skip rows at the top of the file, and to recognise that the field paths are followed by a set of additional header lines. 
 
 .. csv-table::
    :file: ../examples/cafe/skip-and-headers/data.csv

--- a/docs/usage-360.rst
+++ b/docs/usage-360.rst
@@ -1,4 +1,4 @@
-Flatten-Tool for 360Giving
+Flatten Tool for 360Giving
 ==========================
 
 You can also upload the file to http://cove.opendataservices.coop/360

--- a/docs/usage-bods.rst
+++ b/docs/usage-bods.rst
@@ -1,4 +1,4 @@
-Flatten-Tool for BODS
+Flatten Tool for BODS
 +++++++++++++++++++++
 
 flatten and unflatten

--- a/docs/usage-bods.rst
+++ b/docs/usage-bods.rst
@@ -6,9 +6,9 @@ flatten and unflatten
 
 This data standard has a list as the root element,
 as opposed to other standards where the root element is a dict with meta data and a list of data.
-When flattening and unflattening, use the `--root-is-list` option.
+When flattening and unflattening, use the ``--root-is-list`` option.
 
-The id element is `statementID`, so also use the `--id-name` option.
+The id element is ``statementID``, so also use the ``--id-name`` option.
 
 .. code-block:: bash
 
@@ -19,15 +19,15 @@ The id element is `statementID`, so also use the `--id-name` option.
 flatten
 =======
 
-This data standard has three types of statement - `entityStatement`, `personStatement` or `ownershipOrControlStatement`.
+This data standard has three types of statement - ``entityStatement``, ``personStatement`` or ``ownershipOrControlStatement``.
 When using flatten, the spreadsheets produced can become very mixed up.
 
 The main.csv spreadsheet will have data of all three types in it.
 What's worse is that it's unclear what columns apply to what types -
-for instance, `foundingDate` applies to entities but `birthDate` applies to people.
+for instance, ``foundingDate`` applies to entities but ``birthDate`` applies to people.
 However both columns appear in main.csv!
 
-It's also unclear what subsheets apply to which type - for instance there might be a subsheet called `identifiers`
+It's also unclear what subsheets apply to which type - for instance there might be a subsheet called ``identifiers``
 but it's not clear what type this applies to! (The answer is entities)
 
 It would be better to have separate sheets for each type.
@@ -52,7 +52,7 @@ You will have a set of sheets:
   *  3_ownership_interests.csv
   *  3_ownership_main.csv
 
-`birthDate` only appears in `1_person_main.csv` and `foundingDate` only appears in `2_entity_main.csv`, so it is clear which column is for which type.
+``birthDate`` only appears in ``1_person_main.csv`` and ``foundingDate`` only appears in ``2_entity_main.csv``, so it is clear which column is for which type.
 
 Note this works in csv mode.
 If you want to use Excel mode, you'll need to specify 3 separate output files and then combine the sheets in them into one file afterwards by hand.
@@ -69,7 +69,7 @@ unflatten
 Schema
 ------
 
-As well as the options above, also pass the `--schema` option so that types are set correctly. Note the boolean and the integer in the output.
+As well as the options above, also pass the ``--schema`` option so that types are set correctly. Note the boolean and the integer in the output.
 
 .. literalinclude:: ../examples/bods/unflatten/cmd.txt
    :language: bash
@@ -81,8 +81,8 @@ As well as the options above, also pass the `--schema` option so that types are 
 Order is important
 ------------------
 
-In the BODS schema, statements must appear in a certain order. Each of the `entityStatements` or `personStatements`
-referenced by a particular `ownershipOrControlStatement` must appear before that particular statement in the ordered array.
+In the BODS schema, statements must appear in a certain order. Each of the ``entityStatements`` or ``personStatements``
+referenced by a particular ``ownershipOrControlStatement`` must appear before that particular statement in the ordered array.
 
 If you have only one main table, you must make sure the statements appear in the correct order.
 
@@ -120,7 +120,7 @@ For instance:
 create-template
 ===============
 
-You can run this directly on `bods-package.json`:
+You can run this directly on ``bods-package.json``:
 
 .. code-block:: bash
 
@@ -139,7 +139,7 @@ Instead, this process can be followed to obtain clearer templates:
 
     flatten-tool  create-template -f csv -s /path/to/person-statement.json -o . --root-id=statementID
 
-3) Rename all the files in the directory to have `1_person_` at the start.
+3) Rename all the files in the directory to have ``1_person_`` at the start.
 
 If your on a bash shell, you can do this by running:
 
@@ -155,7 +155,7 @@ If your on a bash shell, you can do this by running:
     flatten-tool  create-template -f csv -s /path/to/entity-statement.json -o . --root-id=statementID
 
 
-5) Rename all the new files in the directory to have `2_entity_` at the start.
+5) Rename all the new files in the directory to have ``2_entity_`` at the start.
 
 If your on a bash shell, you can do this by running:
 
@@ -172,7 +172,7 @@ If your on a bash shell, you can do this by running:
     flatten-tool  create-template -f csv -s /path/to/ownership-or-control-statement.json -o . --root-id=statementID
 
 
-7) Rename all the new files in the  directory to have `3_ownership_control_` at the start.
+7) Rename all the new files in the  directory to have ``3_ownership_control_`` at the start.
 
 If your on a bash shell, you can do this by running:
 
@@ -204,7 +204,7 @@ The advantages are:
 
   *  Separate for each type, so it's clear what sheet applies to each type.
   *  Each sheet only has the relevant columns in it, so there is no confusion about whether they apply or not.
-  *  The sheets have numbers at the start, so that when `unflatten` is used the statements will appear in the right order in the output.
+  *  The sheets have numbers at the start, so that when ``unflatten`` is used the statements will appear in the right order in the output.
 
 
 

--- a/docs/usage-iati.rst
+++ b/docs/usage-iati.rst
@@ -1,4 +1,4 @@
-Flatten-Tool for IATI
+Flatten Tool for IATI
 =====================
 
 Currently flatten-tool only supports Spreadsheet->XML for IATI (unflatten), not conversion in the other direction, or automated template creation.
@@ -6,7 +6,7 @@ Currently flatten-tool only supports Spreadsheet->XML for IATI (unflatten), not 
 Convert a spreadsheet to XML
 ----------------------------
 
-For an xlsx file called ``filename.xlsx``:
+For an XLSX file called ``filename.xlsx``:
 
 .. code-block:: bash
 

--- a/docs/usage-ocds.rst
+++ b/docs/usage-ocds.rst
@@ -1,7 +1,7 @@
-Flatten-Tool for OCDS
+Flatten Tool for OCDS
 +++++++++++++++++++++
 
-The `Open Contracting Data Standard (OCDS) <http://standard.open-contracting.org/>`__ has an `unofficial CSV serialization <http://standard.open-contracting.org/latest/en/implementation/serialization/#csv>`__ that can be converted to/from the canonical JSON form using Flatten-Tool.
+The `Open Contracting Data Standard (OCDS) <http://standard.open-contracting.org/>`__ has an `unofficial CSV serialization <http://standard.open-contracting.org/latest/en/implementation/serialization/#csv>`__ that can be converted to/from the canonical JSON form using Flatten Tool.
 
 Templates
 =========
@@ -13,12 +13,12 @@ These are generated with the commands listed in :ref:`ocds-cli-templates` below.
 Web interface
 =============
 
-Flatten-Tool is integrated into the `Open Contracting Data Standard Validator <http://standard.open-contracting.org/validator/>`__, an online tool for validating and converting OCDS files.
+Flatten Tool is integrated into the `Open Contracting Data Standard Validator <http://standard.open-contracting.org/validator/>`__, an online tool for validating and converting OCDS files.
 
 This supports XLSX, but currently only supports uploading CSV (and only one CSV file).
 
-Commandline Usage
-=================
+Command Line Usage
+==================
 
 Converting a JSON file to a spreadsheet
 ---------------------------------------
@@ -29,7 +29,7 @@ Converting a JSON file to a spreadsheet
 
 This will command will create an output called flattened in all the formats we support - currently this is ``flattened.xlsx`` and a ``flattened/`` directory of csv files.
 
-See ``flatten-tool flatten --help`` for details of the commandline options.
+See ``flatten-tool flatten --help`` for details of the command line options.
 
 
 Converting a populated spreadsheet to JSON
@@ -41,7 +41,7 @@ Converting a populated spreadsheet to JSON
 
 And populate this with the package information for your release.
 
-Then, for a populated xlsx template in (in release_populated.xlsx):
+Then, for a populated XLSX template in (in release_populated.xlsx):
 
 .. code-block:: bash
 
@@ -55,7 +55,7 @@ Or for populated CSV files (in the release_populated directory):
 
 These produce a release.json file based on the data in the spreadsheets.
 
-See ``flatten-tool unflatten --help`` for details of the commandline options.
+See ``flatten-tool unflatten --help`` for details of the command line options.
 
 .. _ocds-cli-templates:
 
@@ -70,5 +70,5 @@ Download https://raw.githubusercontent.com/open-contracting/standard/1.0/standar
 
 This will create `template.xlsx` and a `template/` directory of csv files.
 
-See ``flatten-tool create-template --help`` for details of the commandline options.
+See ``flatten-tool create-template --help`` for details of the command line options.
 

--- a/docs/usage-ocds.rst
+++ b/docs/usage-ocds.rst
@@ -68,7 +68,7 @@ Download https://raw.githubusercontent.com/open-contracting/standard/1.0/standar
 
     flatten-tool create-template --root-id=ocid --output-format all --output-name template --schema release-schema.json --main-sheet-name releases
 
-This will create `template.xlsx` and a `template/` directory of csv files.
+This will create ``template.xlsx`` and a ``template/`` directory of csv files.
 
 See ``flatten-tool create-template --help`` for details of the command line options.
 


### PR DESCRIPTION
e.g. so that double-dash command-line options like `--root-list-path` aren't styled as n-dash like *–root-list-path*.

I separated this from #257 as this contains a lot more changes, which are likely easier to review in isolation.

This also:

* Adds a link to the words 'Sheet shapes' in create-template.rst. Otherwise, a reader of create-template.rst is unlikely to understand the reference.
* Corrects typos in the paragraph following that one (have -> has, their -> its).

Those are mixed in because this started as a PR to clean up the latter, and then I noticed that a lot of backticks were incorrect.