### PR TITLE
Lock openpyxl to 2.5 only - not 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Output on the command line is by default less verbose
-
+- openpyxl version 2.5 is required; not tested with version 2.6
 
 ## [0.5.0] - 2018-11-13
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 import sys
 
-install_requires = ['jsonref', 'schema', 'openpyxl>=2.5', 'six', 'pytz', 'xmltodict', 'lxml']
+install_requires = ['jsonref', 'schema', 'openpyxl>=2.5,<2.6', 'six', 'pytz', 'xmltodict', 'lxml']
 
 if sys.version < '3':
     install_requires.append('unicodecsv')


### PR DESCRIPTION
https://github.com/OpenDataServices/flatten-tool/issues/287