### PR TITLE
Resolves issue where CSVs saved in Windows have blank lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - All code has had black and isort applied. These have been added to Travis.
 
+## Fixed
+
+- Remove extra lines in CSVs under Windows https://github.com/OpenDataServices/flatten-tool/pull/350
+
 ## [0.11.0] - 2020-02-21
 
 ### Added

--- a/flattentool/input.py
+++ b/flattentool/input.py
@@ -182,10 +182,7 @@ def merge(base, mergee, debug_info=None):
                             + id_info
                         )
                     warnings_for_ignored_columns(
-                        v,
-                        "because another column treats it as an array or object".format(
-                            key
-                        ),
+                        v, "because another column treats it as an array or object"
                     )
                     continue
                 base_value = base[key].cell_value

--- a/flattentool/output.py
+++ b/flattentool/output.py
@@ -90,6 +90,7 @@ class CSVOutput(SpreadsheetOutput):
         with open(
             os.path.join(self.output_name, self.sheet_prefix + sheet_name + ".csv"),
             "w",
+            newline="",
             encoding="utf-8",
         ) as csv_file:
             dictwriter = csv.DictWriter(csv_file, sheet_header)


### PR DESCRIPTION
Relates to https://github.com/OpenDataServices/flatten-tool/issues/312, one small issue on Windows is behaviour around line endings. Currently saving CSVs leaves blank lines in the CSV. This resolves that. 