### PR TITLE
Translate strings that appear in the cove web interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info
 *.pyc
 *.swp
+*.mo
 .vscode
 .cache
 .coverage

--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[cove-common.flatten-tool]
+file_filter = flattentool/locale/<lang>/LC_MESSAGES/flatten-tool.po
+source_file = flattentool/locale/en/LC_MESSAGES/flatten-tool.po
+source_lang = en
+type = PO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add Spanish translation for all strings that could appear in the CoVE web UI https://github.com/OpenDataServices/flatten-tool/pull/362
+
 ## [0.14.0] - 2020-09-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.15.0] - 2020-10-19
+
 ### Added
 
 - Add Spanish translation for all strings that could appear in the CoVE web UI https://github.com/OpenDataServices/flatten-tool/pull/362

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,2 @@
+# Extraction from Python source files
+[python: **.py]

--- a/flattentool/i18n.py
+++ b/flattentool/i18n.py
@@ -1,0 +1,34 @@
+import gettext
+from pathlib import Path
+
+domain = "flatten-tool"
+locale_dir = str(Path(__file__).parent / "locale")
+
+try:
+    # If we can get the language from Django use that
+    from django.core.exceptions import ImproperlyConfigured
+    from django.utils.translation import get_language
+
+    try:
+        get_language()
+    except ImproperlyConfigured:
+        raise ImportError
+
+    # We set up the translations ourselves, instead of using Django's gettext
+    # function, so that we can have a custom domain and locale directory.
+    translations = {}
+    translations["en"] = gettext.translation(domain, locale_dir, languages=["en"])
+    translations["es"] = gettext.translation(domain, locale_dir, languages=["es"])
+
+    def _(text):
+        lang = get_language()
+        if lang not in translations:
+            lang = "en"
+        return translations[lang].gettext(text)
+
+
+except ImportError:
+    # If there's no Django, call gettext.translation without a languages array,
+    # and it will pick one based on the environment variables.
+    t = gettext.translation(domain, locale_dir)
+    _ = t.gettext

--- a/flattentool/input.py
+++ b/flattentool/input.py
@@ -18,12 +18,9 @@ import pytz
 from openpyxl.utils.cell import _get_column_letter
 
 from flattentool.exceptions import DataErrorWarning
+from flattentool.i18n import _
 from flattentool.lib import isint, parse_sheet_configuration
 from flattentool.ODSReader import ODSReader
-
-
-def _(x):
-    return x
 
 try:
     from zipfile import BadZipFile

--- a/flattentool/input.py
+++ b/flattentool/input.py
@@ -21,6 +21,10 @@ from flattentool.exceptions import DataErrorWarning
 from flattentool.lib import isint, parse_sheet_configuration
 from flattentool.ODSReader import ODSReader
 
+
+def _(x):
+    return x
+
 try:
     from zipfile import BadZipFile
 except ImportError:
@@ -42,9 +46,9 @@ def convert_type(type_string, value, timezone=pytz.timezone("UTC")):
             return Decimal(value)
         except (TypeError, ValueError, InvalidOperation):
             warn(
-                'Non-numeric value "{}" found in number column, returning as string instead.'.format(
-                    value
-                ),
+                _(
+                    'Non-numeric value "{}" found in number column, returning as string instead.'
+                ).format(value),
                 DataErrorWarning,
             )
             return str(value)
@@ -53,9 +57,9 @@ def convert_type(type_string, value, timezone=pytz.timezone("UTC")):
             return int(value)
         except (TypeError, ValueError):
             warn(
-                'Non-integer value "{}" found in integer column, returning as string instead.'.format(
-                    value
-                ),
+                _(
+                    'Non-integer value "{}" found in integer column, returning as string instead.'
+                ).format(value),
                 DataErrorWarning,
             )
             return str(value)
@@ -67,9 +71,9 @@ def convert_type(type_string, value, timezone=pytz.timezone("UTC")):
             return False
         else:
             warn(
-                'Unrecognised value for boolean: "{}", returning as string instead'.format(
-                    value
-                ),
+                _(
+                    'Unrecognised value for boolean: "{}", returning as string instead'
+                ).format(value),
                 DataErrorWarning,
             )
             return str(value)
@@ -85,9 +89,9 @@ def convert_type(type_string, value, timezone=pytz.timezone("UTC")):
                     return [Decimal(x) for x in value.split(";")]
             except (TypeError, ValueError, InvalidOperation):
                 warn(
-                    'Non-numeric value "{}" found in number array column, returning as string array instead.'.format(
-                        value
-                    ),
+                    _(
+                        'Non-numeric value "{}" found in number array column, returning as string array instead).'
+                    ).format(value),
                     DataErrorWarning,
                 )
         if "," in value:
@@ -138,9 +142,9 @@ def merge(base, mergee, debug_info=None):
                 if not isinstance(base[key], TemporaryDict):
                     warnings_for_ignored_columns(
                         v,
-                        "because it treats {} as an array, but another column does not".format(
-                            key
-                        ),
+                        _(
+                            "because it treats {} as an array, but another column does not"
+                        ).format(key),
                     )
                     continue
                 for temporarydict_key, temporarydict_value in value.items():
@@ -151,9 +155,9 @@ def merge(base, mergee, debug_info=None):
                             debug_info,
                         )
                     else:
-                        assert (
-                            temporarydict_key not in base[key]
-                        ), "Overwriting cell {} by mistake".format(temporarydict_value)
+                        assert temporarydict_key not in base[key], _(
+                            "Overwriting cell {} by mistake"
+                        ).format(temporarydict_value)
                         base[key][temporarydict_key] = temporarydict_value
                 for temporarydict_value in value.items_no_keyfield:
                     base[key].items_no_keyfield.append(temporarydict_value)
@@ -163,9 +167,9 @@ def merge(base, mergee, debug_info=None):
                 else:
                     warnings_for_ignored_columns(
                         v,
-                        "because it treats {} as an object, but another column does not".format(
-                            key
-                        ),
+                        _(
+                            "because it treats {} as an object, but another column does not"
+                        ).format(key),
                     )
             else:
                 if not isinstance(base[key], Cell):
@@ -182,7 +186,7 @@ def merge(base, mergee, debug_info=None):
                             + id_info
                         )
                     warnings_for_ignored_columns(
-                        v, "because another column treats it as an array or object"
+                        v, _("because another column treats it as an array or object")
                     )
                     continue
                 base_value = base[key].cell_value
@@ -200,7 +204,9 @@ def merge(base, mergee, debug_info=None):
                             + id_info
                         )
                     warn(
-                        'You may have a duplicate Identifier: We couldn\'t merge these rows with the {}: field "{}" in sheet "{}": one cell has the value: "{}", the other cell has the value: "{}"'.format(
+                        _(
+                            'You may have a duplicate Identifier: We couldn\'t merge these rows with the {}: field "{}" in sheet "{}": one cell has the value: "{}", the other cell has the value: "{}"'
+                        ).format(
                             id_info,
                             key,
                             debug_info.get("sheet_name"),
@@ -332,8 +338,10 @@ class SpreadsheetInput(object):
                         if len(ignoring) >= 3:
                             warn(
                                 (
-                                    'Duplicate heading "{}" found, ignoring '
-                                    'the data in columns {} and {} (sheet: "{}").'
+                                    _(
+                                        'Duplicate heading "{}" found, ignoring '
+                                        'the data in columns {} and {} (sheet: "{}").'
+                                    )
                                 ).format(
                                     actual_heading,
                                     ", ".join(
@@ -350,8 +358,10 @@ class SpreadsheetInput(object):
                         elif len(found[actual_heading]) == 3:
                             warn(
                                 (
-                                    'Duplicate heading "{}" found, ignoring '
-                                    'the data in columns {} and {} (sheet: "{}").'
+                                    _(
+                                        'Duplicate heading "{}" found, ignoring '
+                                        'the data in columns {} and {} (sheet: "{}").'
+                                    )
                                 ).format(
                                     actual_heading,
                                     _get_column_letter(ignoring[0] + 1),
@@ -363,8 +373,10 @@ class SpreadsheetInput(object):
                         else:
                             warn(
                                 (
-                                    'Duplicate heading "{}" found, ignoring '
-                                    'the data in column {} (sheet: "{}").'
+                                    _(
+                                        'Duplicate heading "{}" found, ignoring '
+                                        'the data in column {} (sheet: "{}").'
+                                    )
                                 ).format(
                                     actual_heading,
                                     _get_column_letter(ignoring[0] + 1),
@@ -453,7 +465,7 @@ class SpreadsheetInput(object):
             ordered_items = sorted(cell_source_map.items())
             row_source_map = OrderedDict()
             heading_source_map = OrderedDict()
-            for path, _ in ordered_items:
+            for path, _unused in ordered_items:
                 cells = cell_source_map[path]
                 # Prepare row_source_map key
                 key = "/".join(str(x) for x in path[:-1])
@@ -484,9 +496,9 @@ class SpreadsheetInput(object):
                 for path, location in ordered_items
             )
             for key in row_source_map:
-                assert (
-                    key not in ordered_cell_source_map
-                ), "Row/cell collision: {}".format(key)
+                assert key not in ordered_cell_source_map, _(
+                    "Row/cell collision: {}"
+                ).format(key)
                 ordered_cell_source_map[key] = row_source_map[key]
         return result, ordered_cell_source_map, heading_source_map
 
@@ -496,7 +508,7 @@ def extract_list_to_error_path(path, input):
     for i, item in enumerate(input):
         res = extract_dict_to_error_path(path + [i], item)
         for p in res:
-            assert p not in output, "Already have key {}".format(p)
+            assert p not in output, _("Already have key {}").format(p)
             output[p] = res[p]
     return output
 
@@ -507,27 +519,25 @@ def extract_dict_to_error_path(path, input):
         if isinstance(input[k], list):
             res = extract_list_to_error_path(path + [k], input[k])
             for p in res:
-                assert p not in output, "Already have key {}".format(p)
+                assert p not in output, _("Already have key {}").format(p)
                 output[p] = res[p]
         elif isinstance(input[k], dict):
             res = extract_dict_to_error_path(path + [k], input[k])
             for p in res:
-                assert p not in output, "Already have key {}".format(p)
+                assert p not in output, _("Already have key {}").format(p)
                 output[p] = res[p]
         elif isinstance(input[k], Cell):
             p = tuple(path + [k])
-            assert p not in output, "Already have key {}".format(p)
+            assert p not in output, _("Already have key {}").format(p)
             output[p] = [input[k].cell_location]
             for sub_cell in input[k].sub_cells:
-                assert (
-                    sub_cell.cell_value == input[k].cell_value
-                ), "Two sub-cells have different values: {}, {}".format(
-                    input[k].cell_value, sub_cell.cell_value
-                )
+                assert sub_cell.cell_value == input[k].cell_value, _(
+                    "Two sub-cells have different values: {}, {}"
+                ).format(input[k].cell_value, sub_cell.cell_value)
                 output[p].append(sub_cell.cell_location)
         else:
             raise Exception(
-                "Unexpected result type in the JSON cell tree: {}".format(input[k])
+                _("Unexpected result type in the JSON cell tree: {}").format(input[k])
             )
     return output
 
@@ -550,7 +560,7 @@ def extract_dict_to_value(input):
             output[k] = input[k].cell_value
         else:
             raise Exception(
-                "Unexpected result type in the JSON cell tree: {}".format(input[k])
+                _("Unexpected result type in the JSON cell tree: {}").format(input[k])
             )
     return output
 
@@ -647,7 +657,7 @@ class XLSXInput(SpreadsheetInput):
         except BadZipFile as e:  # noqa
             # TODO when we have python3 only add 'from e' to show exception chain
             raise BadXLSXZipFile(
-                "The supplied file has extension .xlsx but isn't an XLSX file."
+                _("The supplied file has extension .xlsx but isn't an XLSX file.")
             )
 
         self.sheet_names_map = OrderedDict(
@@ -918,9 +928,9 @@ def unflatten_main_with_parser(parser, line, timezone, xml, id_name):
             if isint(path_item):
                 if num == 0:
                     warn(
-                        'Column "{}" has been ignored because it is a number.'.format(
-                            path
-                        ),
+                        _(
+                            'Column "{}" has been ignored because it is a number.'
+                        ).format(path),
                         DataErrorWarning,
                     )
                 continue
@@ -946,9 +956,9 @@ def unflatten_main_with_parser(parser, line, timezone, xml, id_name):
             if isint(next_path_item):
                 if current_type and current_type != "array":
                     raise ValueError(
-                        "There is an array at '{}' when the schema says there should be a '{}'".format(
-                            path_till_now, current_type
-                        )
+                        _(
+                            "There is an array at '{}' when the schema says there should be a '{}'"
+                        ).format(path_till_now, current_type)
                     )
                 list_index = int(next_path_item)
                 current_type = "array"
@@ -960,9 +970,9 @@ def unflatten_main_with_parser(parser, line, timezone, xml, id_name):
                     current_path[path_item] = list_as_dict
                 elif type(list_as_dict) is not ListAsDict:
                     warn(
-                        "Column {} has been ignored, because it treats {} as an array, but another column does not.".format(
-                            path, path_till_now
-                        ),
+                        _(
+                            "Column {} has been ignored, because it treats {} as an array, but another column does not."
+                        ).format(path, path_till_now),
                         DataErrorWarning,
                     )
                     break
@@ -984,9 +994,9 @@ def unflatten_main_with_parser(parser, line, timezone, xml, id_name):
                     current_path[path_item] = new_path
                 elif type(new_path) is ListAsDict or not hasattr(new_path, "items"):
                     warn(
-                        "Column {} has been ignored, because it treats {} as an object, but another column does not.".format(
-                            path, path_till_now
-                        ),
+                        _(
+                            "Column {} has been ignored, because it treats {} as an object, but another column does not."
+                        ).format(path, path_till_now),
                         DataErrorWarning,
                     )
                     break
@@ -998,9 +1008,9 @@ def unflatten_main_with_parser(parser, line, timezone, xml, id_name):
                 and next_path_item
             ):
                 raise ValueError(
-                    "There is an object or list at '{}' but it should be an {}".format(
-                        path_till_now, current_type
-                    )
+                    _(
+                        "There is an object or list at '{}' but it should be an {}"
+                    ).format(path_till_now, current_type)
                 )
 
             ## Other Types
@@ -1012,9 +1022,9 @@ def unflatten_main_with_parser(parser, line, timezone, xml, id_name):
                 #   ^
                 # xml can have an object/array that also has a text value
                 warn(
-                    "Column {} has been ignored, because another column treats it as an array or object".format(
-                        path_till_now
-                    ),
+                    _(
+                        "Column {} has been ignored, because another column treats it as an array or object"
+                    ).format(path_till_now),
                     DataErrorWarning,
                 )
                 continue

--- a/flattentool/json_input.py
+++ b/flattentool/json_input.py
@@ -15,14 +15,10 @@ from warnings import warn
 
 import xmltodict
 
+from flattentool.i18n import _
 from flattentool.input import path_search
 from flattentool.schema import make_sub_sheet_name
 from flattentool.sheet import Sheet
-
-
-def _(x):
-    return x
-
 
 BASIC_TYPES = [str, bool, int, Decimal, type(None)]
 

--- a/flattentool/json_input.py
+++ b/flattentool/json_input.py
@@ -19,6 +19,11 @@ from flattentool.input import path_search
 from flattentool.schema import make_sub_sheet_name
 from flattentool.sheet import Sheet
 
+
+def _(x):
+    return x
+
+
 BASIC_TYPES = [str, bool, int, Decimal, type(None)]
 
 
@@ -146,7 +151,7 @@ class JSONParser(object):
                 if isinstance(rollup, (list,)) and (
                     len(rollup) > 1 or (len(rollup) == 1 and rollup[0] is not True)
                 ):
-                    warn("Using rollUp values from schema, ignoring direct input.")
+                    warn(_("Using rollUp values from schema, ignoring direct input."))
             elif isinstance(rollup, (list,)):
                 if len(rollup) == 1 and os.path.isfile(rollup[0]):
                     # Parse file, one json path per line.
@@ -159,13 +164,17 @@ class JSONParser(object):
                     # Rollup args passed directly at the commandline
                 elif len(rollup) == 1 and rollup[0] is True:
                     warn(
-                        "No fields to rollup found (pass json path directly, as a list in a file, or via a schema)"
+                        _(
+                            "No fields to rollup found (pass json path directly, as a list in a file, or via a schema)"
+                        )
                     )
                 else:
                     self.rollup = set(rollup)
             else:
                 warn(
-                    "Invalid value passed for rollup (pass json path directly, as a list in a file, or via a schema)"
+                    _(
+                        "Invalid value passed for rollup (pass json path directly, as a list in a file, or via a schema)"
+                    )
                 )
 
         if self.xml:
@@ -180,11 +189,13 @@ class JSONParser(object):
             json_filename = None
 
         if json_filename is None and root_json_dict is None:
-            raise ValueError("Etiher json_filename or root_json_dict must be supplied")
+            raise ValueError(
+                _("Etiher json_filename or root_json_dict must be supplied")
+            )
 
         if json_filename is not None and root_json_dict is not None:
             raise ValueError(
-                "Only one of json_file or root_json_dict should be supplied"
+                _("Only one of json_file or root_json_dict should be supplied")
             )
 
         if json_filename:
@@ -222,9 +233,9 @@ class JSONParser(object):
                     if field not in self.schema_parser.flattened.keys():
                         input_not_in_schema.add(field)
                 warn(
-                    "You wanted to preserve the following fields which are not present in the supplied schema: {}".format(
-                        list(input_not_in_schema)
-                    )
+                    _(
+                        "You wanted to preserve the following fields which are not present in the supplied schema: {}"
+                    ).format(list(input_not_in_schema))
                 )
             except AttributeError:
                 # no schema
@@ -260,9 +271,9 @@ class JSONParser(object):
                     nonexistent_input_paths.append(field)
             if len(nonexistent_input_paths) > 0:
                 warn(
-                    "You wanted to preserve the following fields which are not present in the input data: {}".format(
-                        nonexistent_input_paths
-                    )
+                    _(
+                        "You wanted to preserve the following fields which are not present in the input data: {}"
+                    ).format(nonexistent_input_paths)
                 )
 
     def parse_json_dict(
@@ -366,7 +377,9 @@ class JSONParser(object):
 
                         if self.use_titles and not self.schema_parser:
                             warn(
-                                "Warning: No schema was provided so column headings are JSON keys, not titles."
+                                _(
+                                    "Warning: No schema was provided so column headings are JSON keys, not titles."
+                                )
                             )
 
                         if len(value) == 1:
@@ -381,7 +394,7 @@ class JSONParser(object):
 
                                 if type(v) not in BASIC_TYPES:
                                     raise ValueError(
-                                        "Rolled up values must be basic types"
+                                        _("Rolled up values must be basic types")
                                     )
                                 else:
                                     if self.schema_parser:
@@ -458,22 +471,26 @@ class JSONParser(object):
                                     in self.schema_parser.main_sheet
                                 ):
                                     warn(
-                                        'More than one value supplied for "{}". Could not provide rollup, so adding a warning to the relevant cell(s) in the spreadsheet.'.format(
-                                            parent_name + key
-                                        )
+                                        _(
+                                            'More than one value supplied for "{}". Could not provide rollup, so adding a warning to the relevant cell(s) in the spreadsheet.'
+                                        ).format(parent_name + key)
                                     )
                                     flattened_dict[
                                         sheet_key(sheet, parent_name + key + "/0/" + k)
-                                    ] = "WARNING: More than one value supplied, consult the relevant sub-sheet for the data."
+                                    ] = _(
+                                        "WARNING: More than one value supplied, consult the relevant sub-sheet for the data."
+                                    )
                                 elif parent_name + key in self.rollup:
                                     warn(
-                                        'More than one value supplied for "{}". Could not provide rollup, so adding a warning to the relevant cell(s) in the spreadsheet.'.format(
-                                            parent_name + key
-                                        )
+                                        _(
+                                            'More than one value supplied for "{}". Could not provide rollup, so adding a warning to the relevant cell(s) in the spreadsheet.'
+                                        ).format(parent_name + key)
                                     )
                                     flattened_dict[
                                         sheet_key(sheet, parent_name + key + "/0/" + k)
-                                    ] = "WARNING: More than one value supplied, consult the relevant sub-sheet for the data."
+                                    ] = _(
+                                        "WARNING: More than one value supplied, consult the relevant sub-sheet for the data."
+                                    )
 
                     if (
                         self.use_titles
@@ -502,7 +519,7 @@ class JSONParser(object):
                             top_level_of_sub_sheet=True,
                         )
             else:
-                raise ValueError("Unsupported type {}".format(type(value)))
+                raise ValueError(_("Unsupported type {}").format(type(value)))
 
         if top:
             sheet.lines.append(flattened_dict)

--- a/flattentool/locale/en/LC_MESSAGES/flatten-tool.po
+++ b/flattentool/locale/en/LC_MESSAGES/flatten-tool.po
@@ -1,0 +1,232 @@
+# Translations template for flattentool.
+# Copyright (C) 2020 ORGANIZATION
+# This file is distributed under the same license as the flattentool
+# project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: flattentool 0.14.0\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2020-10-16 08:52+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: flattentool/input.py:49
+msgid ""
+"Non-numeric value \"{}\" found in number column, returning as string "
+"instead."
+msgstr ""
+
+#: flattentool/input.py:60
+msgid ""
+"Non-integer value \"{}\" found in integer column, returning as string "
+"instead."
+msgstr ""
+
+#: flattentool/input.py:74
+msgid "Unrecognised value for boolean: \"{}\", returning as string instead"
+msgstr ""
+
+#: flattentool/input.py:92
+msgid ""
+"Non-numeric value \"{}\" found in number array column, returning as "
+"string array instead)."
+msgstr ""
+
+#: flattentool/input.py:145
+msgid "because it treats {} as an array, but another column does not"
+msgstr ""
+
+#: flattentool/input.py:158
+msgid "Overwriting cell {} by mistake"
+msgstr ""
+
+#: flattentool/input.py:170
+msgid "because it treats {} as an object, but another column does not"
+msgstr ""
+
+#: flattentool/input.py:189
+msgid "because another column treats it as an array or object"
+msgstr ""
+
+#: flattentool/input.py:207
+msgid ""
+"You may have a duplicate Identifier: We couldn't merge these rows with "
+"the {}: field \"{}\" in sheet \"{}\": one cell has the value: \"{}\", the"
+" other cell has the value: \"{}\""
+msgstr ""
+
+#: flattentool/input.py:341 flattentool/input.py:361
+msgid ""
+"Duplicate heading \"{}\" found, ignoring the data in columns {} and {} "
+"(sheet: \"{}\")."
+msgstr ""
+
+#: flattentool/input.py:376
+msgid ""
+"Duplicate heading \"{}\" found, ignoring the data in column {} (sheet: "
+"\"{}\")."
+msgstr ""
+
+#: flattentool/input.py:499
+msgid "Row/cell collision: {}"
+msgstr ""
+
+#: flattentool/input.py:511 flattentool/input.py:522 flattentool/input.py:527
+#: flattentool/input.py:531
+msgid "Already have key {}"
+msgstr ""
+
+#: flattentool/input.py:534
+msgid "Two sub-cells have different values: {}, {}"
+msgstr ""
+
+#: flattentool/input.py:540 flattentool/input.py:563
+msgid "Unexpected result type in the JSON cell tree: {}"
+msgstr ""
+
+#: flattentool/input.py:660
+msgid "The supplied file has extension .xlsx but isn't an XLSX file."
+msgstr ""
+
+#: flattentool/input.py:931
+msgid "Column \"{}\" has been ignored because it is a number."
+msgstr ""
+
+#: flattentool/input.py:959
+msgid "There is an array at '{}' when the schema says there should be a '{}'"
+msgstr ""
+
+#: flattentool/input.py:973
+msgid ""
+"Column {} has been ignored, because it treats {} as an array, but another"
+" column does not."
+msgstr ""
+
+#: flattentool/input.py:997
+msgid ""
+"Column {} has been ignored, because it treats {} as an object, but "
+"another column does not."
+msgstr ""
+
+#: flattentool/input.py:1011
+msgid "There is an object or list at '{}' but it should be an {}"
+msgstr ""
+
+#: flattentool/input.py:1025
+msgid ""
+"Column {} has been ignored, because another column treats it as an array "
+"or object"
+msgstr ""
+
+#: flattentool/json_input.py:154
+msgid "Using rollUp values from schema, ignoring direct input."
+msgstr ""
+
+#: flattentool/json_input.py:167
+msgid ""
+"No fields to rollup found (pass json path directly, as a list in a file, "
+"or via a schema)"
+msgstr ""
+
+#: flattentool/json_input.py:175
+msgid ""
+"Invalid value passed for rollup (pass json path directly, as a list in a "
+"file, or via a schema)"
+msgstr ""
+
+#: flattentool/json_input.py:193
+msgid "Etiher json_filename or root_json_dict must be supplied"
+msgstr ""
+
+#: flattentool/json_input.py:198
+msgid "Only one of json_file or root_json_dict should be supplied"
+msgstr ""
+
+#: flattentool/json_input.py:236
+msgid ""
+"You wanted to preserve the following fields which are not present in the "
+"supplied schema: {}"
+msgstr ""
+
+#: flattentool/json_input.py:274
+msgid ""
+"You wanted to preserve the following fields which are not present in the "
+"input data: {}"
+msgstr ""
+
+#: flattentool/json_input.py:380
+msgid ""
+"Warning: No schema was provided so column headings are JSON keys, not "
+"titles."
+msgstr ""
+
+#: flattentool/json_input.py:397
+msgid "Rolled up values must be basic types"
+msgstr ""
+
+#: flattentool/json_input.py:474 flattentool/json_input.py:485
+msgid ""
+"More than one value supplied for \"{}\". Could not provide rollup, so "
+"adding a warning to the relevant cell(s) in the spreadsheet."
+msgstr ""
+
+#: flattentool/json_input.py:480 flattentool/json_input.py:491
+msgid ""
+"WARNING: More than one value supplied, consult the relevant sub-sheet for"
+" the data."
+msgstr ""
+
+#: flattentool/json_input.py:522
+msgid "Unsupported type {}"
+msgstr ""
+
+#: flattentool/output.py:71 flattentool/output.py:147
+msgid ""
+"Character(s) in '{}' are not allowed in a spreadsheet cell. Those "
+"character(s) will be removed"
+msgstr ""
+
+#: flattentool/schema.py:145
+msgid "One of schema_filename or root_schema_dict must be supplied"
+msgstr ""
+
+#: flattentool/schema.py:149
+msgid "Only one of schema_filename or root_schema_dict should be supplied"
+msgstr ""
+
+#: flattentool/schema.py:192
+msgid "Field {} does not have a title, skipping."
+msgstr ""
+
+#: flattentool/schema.py:344
+msgid "Field {}{}/0/{} is missing a title, skipping."
+msgstr ""
+
+#: flattentool/schema.py:350
+msgid "Field {}{} does not have a title, skipping it and all its children."
+msgstr ""
+
+#: flattentool/schema.py:390
+msgid ""
+"Unknown type_set: {}, did you forget to explicity set the \"type\" key on"
+" \"items\"?"
+msgstr ""
+
+#: flattentool/schema.py:423
+msgid ""
+"Unrecognised types {} for property \"{}\" with context \"{}\",so this "
+"property has been ignored."
+msgstr ""
+
+#: flattentool/schema.py:431
+msgid "Skipping field \"{}\", because it has no properties."
+msgstr ""
+

--- a/flattentool/locale/es/LC_MESSAGES/flatten-tool.po
+++ b/flattentool/locale/es/LC_MESSAGES/flatten-tool.po
@@ -1,0 +1,280 @@
+# Translations template for flattentool.
+# Copyright (C) 2020 ORGANIZATION
+# This file is distributed under the same license as the flattentool
+# project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# 
+# Translators:
+# Maria Esther Cervantes <mcervantes@cds.com.py>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: flattentool 0.14.0\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2020-10-16 08:52+0000\n"
+"PO-Revision-Date: 2020-10-08 16:02+0000\n"
+"Last-Translator: Maria Esther Cervantes <mcervantes@cds.com.py>, 2020\n"
+"Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/59127/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: flattentool/input.py:49
+msgid ""
+"Non-numeric value \"{}\" found in number column, returning as string "
+"instead."
+msgstr ""
+"Un valor no numérico \"{}\" se encuentra en la columna numérica y se "
+"devuelve como una cadena."
+
+#: flattentool/input.py:60
+msgid ""
+"Non-integer value \"{}\" found in integer column, returning as string "
+"instead."
+msgstr ""
+"Un valor no-integral \"{}\" se encuentra en la columna integral y se "
+"devuelve como una cadena."
+
+#: flattentool/input.py:74
+msgid "Unrecognised value for boolean: \"{}\", returning as string instead"
+msgstr ""
+"Un valor no reconocido para boolean:  \"{}\", se devuelve como una cadena."
+
+#: flattentool/input.py:92
+msgid ""
+"Non-numeric value \"{}\" found in number array column, returning as string "
+"array instead)."
+msgstr ""
+"Un valor no numérico \"{}\" se encuentra en la columna numérica y se "
+"devuelve como una cadena)."
+
+#: flattentool/input.py:145
+msgid "because it treats {} as an array, but another column does not"
+msgstr "porque trata  {} como una matriz, pero otra columna no lo hace"
+
+#: flattentool/input.py:158
+msgid "Overwriting cell {} by mistake"
+msgstr "Sobrescritura de celda {} por error"
+
+#: flattentool/input.py:170
+msgid "because it treats {} as an object, but another column does not"
+msgstr "porque trata {} como un objeto, cuando otra columna no lo hace"
+
+#: flattentool/input.py:189
+msgid "because another column treats it as an array or object"
+msgstr "porque otra columna lo trata como una matriz u objeto"
+
+#: flattentool/input.py:207
+msgid ""
+"You may have a duplicate Identifier: We couldn't merge these rows with the "
+"{}: field \"{}\" in sheet \"{}\": one cell has the value: \"{}\", the other "
+"cell has the value: \"{}\""
+msgstr ""
+"Puede tener un Identificador duplicado: No pudimos combinar estas filas con "
+"el  {}: campo \"{}\" en la hoja  \"{}\" con una celda que tiene  \"{}\", la "
+"otra célula tiene: \"{}\" "
+
+#: flattentool/input.py:341 flattentool/input.py:361
+msgid ""
+"Duplicate heading \"{}\" found, ignoring the data in columns {} and {} "
+"(sheet: \"{}\")."
+msgstr ""
+"Se encontró un encabezado duplicado  \"{}\", ignorando los datos en la "
+"columna {} y {} (hoja:: \"{}\")."
+
+#: flattentool/input.py:376
+msgid ""
+"Duplicate heading \"{}\" found, ignoring the data in column {} (sheet: "
+"\"{}\")."
+msgstr ""
+"Se encontró un encabezado duplicado \"{}\", ignorando los datos en la "
+"columna {} (hoja:: \"{}\")."
+
+#: flattentool/input.py:499
+msgid "Row/cell collision: {}"
+msgstr "Colisión de fila/célula: {}"
+
+#: flattentool/input.py:511 flattentool/input.py:522 flattentool/input.py:527
+#: flattentool/input.py:531
+msgid "Already have key {}"
+msgstr "Ya tiene clave {}"
+
+#: flattentool/input.py:534
+msgid "Two sub-cells have different values: {}, {}"
+msgstr "Dos sub-células tienen valores diferentes: {}, {}"
+
+#: flattentool/input.py:540 flattentool/input.py:563
+msgid "Unexpected result type in the JSON cell tree: {}"
+msgstr "Un tipo de resultado inesperado en el árbol de celdas JSON: {}"
+
+#: flattentool/input.py:660
+msgid "The supplied file has extension .xlsx but isn't an XLSX file."
+msgstr ""
+"El archivo suministrado tiene la extensión .xlsx pero no es un archivo XLSX."
+
+#: flattentool/input.py:931
+msgid "Column \"{}\" has been ignored because it is a number."
+msgstr "La columna \"{}\" se ha ignorado porque es un número."
+
+#: flattentool/input.py:959
+msgid "There is an array at '{}' when the schema says there should be a '{}'"
+msgstr ""
+"Hay una matriz en '{}' cuando el esquema dice que debería haber un '{}'"
+
+#: flattentool/input.py:973
+msgid ""
+"Column {} has been ignored, because it treats {} as an array, but another "
+"column does not."
+msgstr ""
+"La columna {} ha sido ignorada porque trata a {} como una matriz, pero otra "
+"columna no."
+
+#: flattentool/input.py:997
+msgid ""
+"Column {} has been ignored, because it treats {} as an object, but another "
+"column does not."
+msgstr ""
+"La columna {} ha sido ignorada porque trata a {} como un objeto, pero otra "
+"columna no."
+
+#: flattentool/input.py:1011
+msgid "There is an object or list at '{}' but it should be an {}"
+msgstr "Hay un objeto o una lista en '{}' pero debería ser un {}"
+
+#: flattentool/input.py:1025
+msgid ""
+"Column {} has been ignored, because another column treats it as an array or "
+"object"
+msgstr ""
+"La columna {} se ha ignorado porque otra columna la trata como una matriz u "
+"objeto"
+
+#: flattentool/json_input.py:154
+msgid "Using rollUp values from schema, ignoring direct input."
+msgstr "Usar valores acumulados del esquema, ignorando la entrada directa."
+
+#: flattentool/json_input.py:167
+msgid ""
+"No fields to rollup found (pass json path directly, as a list in a file, or "
+"via a schema)"
+msgstr ""
+"No se encontraron campos para resumir (pase la ruta json directamente, como "
+"una lista en un archivo o mediante un esquema)"
+
+#: flattentool/json_input.py:175
+msgid ""
+"Invalid value passed for rollup (pass json path directly, as a list in a "
+"file, or via a schema)"
+msgstr ""
+"Se pasó un valor no válido para el resumen (pase la ruta json directamente, "
+"como una lista en un archivo o mediante un esquema)"
+
+#: flattentool/json_input.py:193
+msgid "Etiher json_filename or root_json_dict must be supplied"
+msgstr "Se debe proporcionar el r json_filename o root_json_dict"
+
+#: flattentool/json_input.py:198
+msgid "Only one of json_file or root_json_dict should be supplied"
+msgstr "Solo uno de json_filename o root_json_dict debe de proporcionarse"
+
+#: flattentool/json_input.py:236
+msgid ""
+"You wanted to preserve the following fields which are not present in the "
+"supplied schema: {}"
+msgstr ""
+"Quería conservar los siguientes campos que no están presentes en el esquema "
+"proporcionado: {}"
+
+#: flattentool/json_input.py:274
+msgid ""
+"You wanted to preserve the following fields which are not present in the "
+"input data: {}"
+msgstr ""
+"Quería conservar los siguientes campos que no están presentes en los datos "
+"de entrada: {}"
+
+#: flattentool/json_input.py:380
+msgid ""
+"Warning: No schema was provided so column headings are JSON keys, not "
+"titles."
+msgstr ""
+"Advertencia: No se proporcionó ningún esquema, por lo que los encabezados de"
+" las columnas son claves JSON, no títulos."
+
+#: flattentool/json_input.py:397
+msgid "Rolled up values must be basic types"
+msgstr "Los valores acumulados deben ser tipos básicos"
+
+#: flattentool/json_input.py:474 flattentool/json_input.py:485
+msgid ""
+"More than one value supplied for \"{}\". Could not provide rollup, so adding"
+" a warning to the relevant cell(s) in the spreadsheet."
+msgstr ""
+"Más de un valor proporcionado para \"{}\". No se pudo proporcionar el "
+"resumen, por lo que se agregó una advertencia a las celda(s) relevantes en "
+"la hoja de cálculo."
+
+#: flattentool/json_input.py:480 flattentool/json_input.py:491
+msgid ""
+"WARNING: More than one value supplied, consult the relevant sub-sheet for "
+"the data."
+msgstr ""
+"ADVERTENCIA: Más de un valor suministrado, consulte la sub-hoja "
+"correspondiente para los datos."
+
+#: flattentool/json_input.py:522
+msgid "Unsupported type {}"
+msgstr "Tipo no admitido {}"
+
+#: flattentool/output.py:71 flattentool/output.py:147
+msgid ""
+"Character(s) in '{}' are not allowed in a spreadsheet cell. Those "
+"character(s) will be removed"
+msgstr ""
+"Los caracteres de '{}' no están permitidos en una celda de hoja de cálculo. "
+"Se eliminarán esos carácter(es)"
+
+#: flattentool/schema.py:145
+msgid "One of schema_filename or root_schema_dict must be supplied"
+msgstr "Se debe proporcionar un schema_filename o root_schema_dict"
+
+#: flattentool/schema.py:149
+msgid "Only one of schema_filename or root_schema_dict should be supplied"
+msgstr "Solo se debe proporcionar un schema_filename o root_schema_dict"
+
+#: flattentool/schema.py:192
+msgid "Field {} does not have a title, skipping."
+msgstr "El campo {} no tiene título, se omite."
+
+#: flattentool/schema.py:344
+msgid "Field {}{}/0/{} is missing a title, skipping."
+msgstr "Al campo {}{}/0/{}  le falta un título y se salta."
+
+#: flattentool/schema.py:350
+msgid "Field {}{} does not have a title, skipping it and all its children."
+msgstr ""
+"El campo {}{} no tiene título, lo omite y todos sus elementos secundarios."
+
+#: flattentool/schema.py:390
+msgid ""
+"Unknown type_set: {}, did you forget to explicity set the \"type\" key on "
+"\"items\"?"
+msgstr ""
+"Type_set desconocido: {}, ¿olvidó establecer explícitamente la clave "
+"\"type\" en \"items\"?"
+
+#: flattentool/schema.py:423
+msgid ""
+"Unrecognised types {} for property \"{}\" with context \"{}\",so this "
+"property has been ignored."
+msgstr ""
+"Tipos no reconocidos {} para la propiedad \"{}\" con contexto \"{}\", por lo"
+" que esta propiedad se ha ignorado."
+
+#: flattentool/schema.py:431
+msgid "Skipping field \"{}\", because it has no properties."
+msgstr "Omitiendo el campo \"{}\", porque no tiene propiedades."

--- a/flattentool/output.py
+++ b/flattentool/output.py
@@ -17,6 +17,10 @@ from openpyxl.cell.cell import ILLEGAL_CHARACTERS_RE
 from flattentool.exceptions import DataErrorWarning
 
 
+def _(x):
+    return x
+
+
 class SpreadsheetOutput(object):
     # output_name is given a default here, partly to help with tests,
     # but should have been defined by the time we get here.
@@ -64,9 +68,9 @@ class XLSXOutput(SpreadsheetOutput):
                     new_value = ILLEGAL_CHARACTERS_RE.sub("", value)
                     if new_value != value:
                         warn(
-                            "Character(s) in '{}' are not allowed in a spreadsheet cell. Those character(s) will be removed".format(
-                                value
-                            ),
+                            _(
+                                "Character(s) in '{}' are not allowed in a spreadsheet cell. Those character(s) will be removed"
+                            ).format(value),
                             DataErrorWarning,
                         )
                     value = new_value
@@ -140,9 +144,9 @@ class ODSOutput(SpreadsheetOutput):
                     new_value = ILLEGAL_CHARACTERS_RE.sub("", value)
                     if new_value != value:
                         warn(
-                            "Character(s) in '{}' are not allowed in a spreadsheet cell. Those character(s) will be removed".format(
-                                value
-                            ),
+                            _(
+                                "Character(s) in '{}' are not allowed in a spreadsheet cell. Those character(s) will be removed"
+                            ).format(value),
                             DataErrorWarning,
                         )
                     value = new_value

--- a/flattentool/output.py
+++ b/flattentool/output.py
@@ -15,10 +15,7 @@ from odf.opendocument import OpenDocumentSpreadsheet
 from openpyxl.cell.cell import ILLEGAL_CHARACTERS_RE
 
 from flattentool.exceptions import DataErrorWarning
-
-
-def _(x):
-    return x
+from flattentool.i18n import _
 
 
 class SpreadsheetOutput(object):

--- a/flattentool/schema.py
+++ b/flattentool/schema.py
@@ -20,6 +20,10 @@ else:
     import urlparse
 
 
+def _(x):
+    return x
+
+
 def get_property_type_set(property_schema_dict):
     property_type = property_schema_dict.get("type", [])
     if not isinstance(property_type, list):
@@ -138,11 +142,11 @@ class SchemaParser(object):
 
         if root_schema_dict is None and schema_filename is None:
             raise ValueError(
-                "One of schema_filename or root_schema_dict must be supplied"
+                _("One of schema_filename or root_schema_dict must be supplied")
             )
         if root_schema_dict is not None and schema_filename is not None:
             raise ValueError(
-                "Only one of schema_filename or root_schema_dict should be supplied"
+                _("Only one of schema_filename or root_schema_dict should be supplied")
             )
         if schema_filename:
             if schema_filename.startswith("http"):
@@ -185,7 +189,7 @@ class SchemaParser(object):
         for field, title in fields:
             if self.use_titles:
                 if not title:
-                    warn("Field {} does not have a title, skipping.".format(field))
+                    warn(_("Field {} does not have a title, skipping.").format(field))
                 else:
                     self.main_sheet.append(title)
                     self.main_sheet.titles[field] = title
@@ -337,15 +341,15 @@ class SchemaParser(object):
                             if self.use_titles:
                                 if not child_title or parent_title is None:
                                     warn(
-                                        "Field {}{}/0/{} is missing a title, skipping.".format(
-                                            parent_path, property_name, field
-                                        )
+                                        _(
+                                            "Field {}{}/0/{} is missing a title, skipping."
+                                        ).format(parent_path, property_name, field)
                                     )
                                 elif not title:
                                     warn(
-                                        "Field {}{} does not have a title, skipping it and all its children.".format(
-                                            parent_path, property_name
-                                        )
+                                        _(
+                                            "Field {}{} does not have a title, skipping it and all its children."
+                                        ).format(parent_path, property_name)
                                     )
                                 else:
                                     # This code only works for arrays that are at 0 or 1 layer of nesting
@@ -383,9 +387,9 @@ class SchemaParser(object):
 
                     else:
                         raise ValueError(
-                            'Unknown type_set: {}, did you forget to explicity set the "type" key on "items"?'.format(
-                                type_set
-                            )
+                            _(
+                                'Unknown type_set: {}, did you forget to explicity set the "type" key on "items"?'
+                            ).format(type_set)
                         )
                 elif "string" in property_type_set or not property_type_set:
                     # We only check for date here, because its the only format
@@ -416,13 +420,15 @@ class SchemaParser(object):
                     yield property_name, title
                 else:
                     warn(
-                        'Unrecognised types {} for property "{}" with context "{}",'
-                        "so this property has been ignored.".format(
-                            repr(property_type_set), property_name, parent_path
-                        )
+                        _(
+                            'Unrecognised types {} for property "{}" with context "{}",'
+                            "so this property has been ignored."
+                        ).format(repr(property_type_set), property_name, parent_path)
                     )
 
         else:
             warn(
-                'Skipping field "{}", because it has no properties.'.format(parent_path)
+                _('Skipping field "{}", because it has no properties.').format(
+                    parent_path
+                )
             )

--- a/flattentool/schema.py
+++ b/flattentool/schema.py
@@ -10,6 +10,7 @@ from warnings import warn
 
 import jsonref
 
+from flattentool.i18n import _
 from flattentool.sheet import Sheet
 
 if sys.version_info[:2] > (3, 0):
@@ -18,10 +19,6 @@ else:
     import urllib
 
     import urlparse
-
-
-def _(x):
-    return x
 
 
 def get_property_type_set(property_schema_dict):

--- a/flattentool/xml_output.py
+++ b/flattentool/xml_output.py
@@ -4,11 +4,6 @@ from warnings import warn
 from flattentool.exceptions import DataErrorWarning
 from flattentool.sort_xml import XMLSchemaWalker, sort_element
 
-
-def _(x):
-    return x
-
-
 try:
     import lxml.etree as ET
 

--- a/flattentool/xml_output.py
+++ b/flattentool/xml_output.py
@@ -4,6 +4,11 @@ from warnings import warn
 from flattentool.exceptions import DataErrorWarning
 from flattentool.sort_xml import XMLSchemaWalker, sort_element
 
+
+def _(x):
+    return x
+
+
 try:
     import lxml.etree as ET
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,3 +8,4 @@ sphinx
 sphinx_rtd_theme
 isort
 flake8
+transifex-client

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,13 @@
 [flake8]
 # Ignore style checking, because black does this for us
 ignore = E,W
+
+[extract_messages]
+mapping_file = babel.cfg
+output-file = flattentool/locale/en/LC_MESSAGES/flatten-tool.po
+
+[compile_catalog]
+directory = flattentool/locale
+domain = flatten-tool
+use-fuzzy = yes
+

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
 
 setup(
     name="flattentool",
-    version="0.14.0",
+    version="0.15.0",
     author="Open Data Services",
     author_email="code@opendataservices.coop",
     packages=["flattentool"],

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,31 @@
 from setuptools import setup
+from setuptools.command.develop import develop
+from setuptools.command.install import install
+
+
+def run_compile_catalog(setuptools_command):
+    from babel.messages.frontend import compile_catalog
+
+    compiler = compile_catalog(setuptools_command.distribution)
+    option_dict = setuptools_command.distribution.get_option_dict("compile_catalog")
+    compiler.domain = [option_dict["domain"][1]]
+    compiler.directory = option_dict["directory"][1]
+    compiler.use_fuzzy = option_dict["use_fuzzy"][1]
+    compiler.run()
+
+
+# From https://stackoverflow.com/questions/40051076/compile-translation-files-when-calling-setup-py-install
+class InstallWithCompile(install):
+    def run(self):
+        run_compile_catalog(self)
+        super().run()
+
+
+class DevelopWithCompile(develop):
+    def run(self):
+        run_compile_catalog(self)
+        super().run()
+
 
 install_requires = [
     "jsonref",
@@ -22,4 +49,7 @@ setup(
     description="Tools for generating CSV and other flat versions of the structured data",
     install_requires=install_requires,
     extras_require={"HTTP": ["requests"]},
+    cmdclass={"install": InstallWithCompile, "develop": DevelopWithCompile,},
+    package_data={"flattentool": ["locale/*/*/*.mo", "locale/*/*/*.po"]},
+    setup_requires=["babel"],
 )


### PR DESCRIPTION
Currently strings that only appear on the commandline, e.g. help messages are not translated.