### PR TITLE
fix: Apply backport only if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.17.1] - 2021-07-21
+
+### Fixed
+
+- Use backports-datetime-fromisoformat only if needed, to fix PyPy 3.7 support https://github.com/OpenDataServices/flatten-tool/pull/386
+
 ## [0.17.0] - 2021-04-27
 
 ### Removed

--- a/flattentool/ODSReader.py
+++ b/flattentool/ODSReader.py
@@ -23,7 +23,10 @@ import odf.opendocument
 from odf.table import Table, TableCell, TableRow
 
 # Backport for datetime.fromisoformat, which is new in Python 3.7
-backports.datetime_fromisoformat.MonkeyPatch.patch_fromisoformat()
+try:
+    _ = datetime.fromisoformat
+except AttributeError:
+    backports.datetime_fromisoformat.MonkeyPatch.patch_fromisoformat()
 
 
 # http://stackoverflow.com/a/4544699/1846474

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install_requires = [
 
 setup(
     name="flattentool",
-    version="0.17.0",
+    version="0.17.1",
     author="Open Data Services",
     author_email="code@opendataservices.coop",
     packages=["flattentool"],


### PR DESCRIPTION
backports-datetime-fromisoformat is incompatible with PyPy (it calls `ctypes.pythonapi`). So, use the same test as in https://github.com/movermeyer/backports.datetime_fromisoformat/blob/master/backports/datetime_fromisoformat/__init__.py#L31 to determine whether to apply the patch. PyPy 3.7 already defines fromisoformat, so it will not be patched.

Blocks https://github.com/open-contracting/lib-cove-ocds/issues/96