### PR TITLE
actions: Add Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8']
+        python-version: [ '3.6', '3.7', '3.8', '3.9']
     steps:
     - uses: actions/checkout@v2
     - name: Setup python

--- a/examples/help/unflatten/expected.txt
+++ b/examples/help/unflatten/expected.txt
@@ -1,5 +1,6 @@
-usage: flatten-tool unflatten [-h] -f {csv,ods,xlsx} [--xml] [--id-name ID_NAME]
-                              [-b BASE_JSON] [-m ROOT_LIST_PATH] [-e ENCODING]
+usage: flatten-tool unflatten [-h] -f {csv,ods,xlsx} [--xml]
+                              [--id-name ID_NAME] [-b BASE_JSON]
+                              [-m ROOT_LIST_PATH] [-e ENCODING]
                               [-o OUTPUT_NAME] [-c CELL_SOURCE_MAP]
                               [-a HEADING_SOURCE_MAP]
                               [--timezone-name TIMEZONE_NAME] [-r ROOT_ID]
@@ -9,7 +10,7 @@ usage: flatten-tool unflatten [-h] -f {csv,ods,xlsx} [--xml] [--id-name ID_NAME]
                               [--metatab-schema METATAB_SCHEMA]
                               [--metatab-only]
                               [--metatab-vertical-orientation]
-                              [--xml-schema [XML_SCHEMA [XML_SCHEMA ...]]]
+                              [--xml-schema [XML_SCHEMA ...]]
                               [--default-configuration DEFAULT_CONFIGURATION]
                               [--root-is-list] [--disable-local-refs]
                               [--xml-comment XML_COMMENT]
@@ -64,7 +65,7 @@ optional arguments:
   --metatab-vertical-orientation
                         Read metatab so that headings are in the first column
                         and data is read vertically. Only for XLSX not CSV
-  --xml-schema [XML_SCHEMA [XML_SCHEMA ...]]
+  --xml-schema [XML_SCHEMA ...]
                         Path to one or more XML schemas (used for sorting)
   --default-configuration DEFAULT_CONFIGURATION
                         Comma separated list of default parsing commands for

--- a/flattentool/tests/test_docs.py
+++ b/flattentool/tests/test_docs.py
@@ -15,7 +15,7 @@ def _get_examples_in_docs_data():
     examples_in_docs_data = []
     for root, dirs, files in os.walk("examples"):
         for filename in files:
-            if "xlsx" in root and sys.version_info[:2] < (3, 4):
+            if root == "examples/help/unflatten" and sys.version_info[:2] < (3, 9):
                 continue
             if "cmd.txt" in filename:
                 examples_in_docs_data.append((root, filename))
@@ -133,7 +133,11 @@ def test_example_in_doc(root, filename):
 
 
 def test_expected_number_of_examples_in_docs_data():
-    assert len(examples_in_docs_data) == 61
+    expected = 61
+    # See _get_examples_in_docs_data()
+    if sys.version_info[:2] < (3, 9):
+        expected -= 1
+    assert len(examples_in_docs_data) == expected
 
 
 def _simplify_warnings(lines):


### PR DESCRIPTION
Have to skip a test in versions older than 3.9

Also removed a Python version check that does not apply any more

https://github.com/OpenDataServices/flatten-tool/issues/390