### PR TITLE
fix: Add compatibility for both jsonref 0.x and 1.x

### DIFF
--- a/flattentool/schema.py
+++ b/flattentool/schema.py
@@ -97,17 +97,16 @@ class JsonLoaderLocalRefUsedWhenLocalRefsDisabled(Exception):
     pass
 
 
-class JsonLoaderLocalRefsDisabled(jsonref.JsonLoader):
-    def __call__(self, uri, **kwargs):
-        if self.is_ref_local(uri):
-            raise JsonLoaderLocalRefUsedWhenLocalRefsDisabled(
-                "Local Ref Used When Local Refs Disabled: " + uri
-            )
-        else:
-            return super(JsonLoaderLocalRefsDisabled, self).__call__(uri, **kwargs)
+def jsonloader_local_refs_disabled(uri, **kwargs):
+    if is_ref_local(uri):
+        raise JsonLoaderLocalRefUsedWhenLocalRefsDisabled(
+            "Local Ref Used When Local Refs Disabled: " + uri
+        )
+    return jsonref.jsonloader(uri, **kwargs)
 
-    def is_ref_local(self, uri):
-        return uri[:7].lower() != "http://" and uri[:8].lower() != "https://"
+
+def is_ref_local(uri):
+    return uri[:7].lower() != "http://" and uri[:8].lower() != "https://"
 
 
 class SchemaParser(object):
@@ -159,7 +158,7 @@ class SchemaParser(object):
                         self.root_schema_dict = jsonref.load(
                             schema_file,
                             object_pairs_hook=OrderedDict,
-                            loader=JsonLoaderLocalRefsDisabled(),
+                            loader=jsonloader_local_refs_disabled,
                         )
                 else:
                     if sys.version_info[:2] > (3, 0):

--- a/flattentool/tests/test_schema_parser.py
+++ b/flattentool/tests/test_schema_parser.py
@@ -2,11 +2,7 @@ from collections import OrderedDict
 
 import pytest
 
-from flattentool.schema import (
-    JsonLoaderLocalRefsDisabled,
-    SchemaParser,
-    get_property_type_set,
-)
+from flattentool.schema import SchemaParser, get_property_type_set, is_ref_local
 from flattentool.sheet import Sheet
 
 type_string = {"type": "string"}
@@ -767,7 +763,7 @@ test_json_loader_local_refs_disabled_is_ref_local_data_returns_true = [
     "data", test_json_loader_local_refs_disabled_is_ref_local_data_returns_true
 )
 def test_json_loader_local_refs_disabled_is_ref_local_true(data):
-    assert True == JsonLoaderLocalRefsDisabled().is_ref_local(data)
+    assert True == is_ref_local(data)
 
 
 test_json_loader_local_refs_disabled_is_ref_local_data_returns_false = [
@@ -784,4 +780,4 @@ test_json_loader_local_refs_disabled_is_ref_local_data_returns_false = [
     "data", test_json_loader_local_refs_disabled_is_ref_local_data_returns_false
 )
 def test_json_loader_local_refs_disabled_is_ref_local_true(data):  # noqa
-    assert False == JsonLoaderLocalRefsDisabled().is_ref_local(data)
+    assert False == is_ref_local(data)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ class DevelopWithCompile(develop):
 
 
 install_requires = [
-    "jsonref<1",
+    "jsonref",
     "schema",
     "openpyxl>=2.6,!=3.0.2",
     "pytz",


### PR DESCRIPTION
In 0.x, jsonref.jsonloader is set to `JsonLoader()`. In 1.x, it's just a regular function. Code now works in both.