### PR TITLE
python: Add 3.10 and 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9']
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         jsonref-version: ["==0.3", ">1"]
     steps:
     - uses: actions/checkout@v2

--- a/examples/help/unflatten/expected.txt
+++ b/examples/help/unflatten/expected.txt
@@ -10,7 +10,7 @@ usage: flatten-tool unflatten [-h] -f {csv,ods,xlsx} [--xml]
                               [--metatab-schema METATAB_SCHEMA]
                               [--metatab-only]
                               [--metatab-vertical-orientation]
-                              [--xml-schema [XML_SCHEMA ...]]
+                              [--xml-schema [XML_SCHEMA [XML_SCHEMA ...]]]
                               [--default-configuration DEFAULT_CONFIGURATION]
                               [--root-is-list] [--disable-local-refs]
                               [--xml-comment XML_COMMENT]
@@ -65,7 +65,7 @@ optional arguments:
   --metatab-vertical-orientation
                         Read metatab so that headings are in the first column
                         and data is read vertically. Only for XLSX not CSV
-  --xml-schema [XML_SCHEMA ...]
+  --xml-schema [XML_SCHEMA [XML_SCHEMA ...]]
                         Path to one or more XML schemas (used for sorting)
   --default-configuration DEFAULT_CONFIGURATION
                         Comma separated list of default parsing commands for

--- a/flattentool/tests/test_docs.py
+++ b/flattentool/tests/test_docs.py
@@ -15,7 +15,10 @@ def _get_examples_in_docs_data():
     examples_in_docs_data = []
     for root, dirs, files in os.walk("examples"):
         for filename in files:
-            if root == "examples/help/unflatten" and sys.version_info[:2] < (3, 9):
+            if root.startswith("examples/help/") and sys.version_info[:2] != (3, 8):
+                # Different versions of python produce differently formatted help output.
+                # We only test in one version, Python 3.8.
+                # (Same as we lint code with, so dev's can have one virtual env)
                 continue
             if "cmd.txt" in filename:
                 examples_in_docs_data.append((root, filename))
@@ -135,8 +138,9 @@ def test_example_in_doc(root, filename):
 def test_expected_number_of_examples_in_docs_data():
     expected = 61
     # See _get_examples_in_docs_data()
-    if sys.version_info[:2] < (3, 9):
-        expected -= 1
+    if sys.version_info[:2] != (3, 8):
+        expected -= 3
+        # number of help tests
     assert len(examples_in_docs_data) == expected
 
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 -e .[HTTP]
 urllib3>=1.24.2
-pytest<5
+pytest
 pytest-cov
 coveralls
 pytest-localserver


### PR DESCRIPTION
https://github.com/OpenDataServices/flatten-tool/issues/390

Need a later version of pytest to avoid a bug

Only test help examples in python 3.8
* output differs between versions
* same version as we use for linting