### PR TITLE
fix: Import backports-datetime-fromisoformat only if needed, to fix PyPy 3.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7']
         jsonref-version: ["==0.3", ">1"]
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Import backports-datetime-fromisoformat only if needed, to fix PyPy 3.7 support
+
 ## [0.19.0] - 2022-11-16
 
 ### Fixed

--- a/flattentool/ODSReader.py
+++ b/flattentool/ODSReader.py
@@ -18,7 +18,6 @@
 from collections import OrderedDict
 from datetime import datetime
 
-import backports.datetime_fromisoformat
 import odf.opendocument
 from odf.table import Table, TableCell, TableRow
 
@@ -26,6 +25,8 @@ from odf.table import Table, TableCell, TableRow
 try:
     _ = datetime.fromisoformat
 except AttributeError:
+    import backports.datetime_fromisoformat
+
     backports.datetime_fromisoformat.MonkeyPatch.patch_fromisoformat()
 
 


### PR DESCRIPTION
Follows #386. Now merely importing backports causes an error on PyPy.

```
  File "/opt/hostedtoolcache/PyPy/3.7.13/x64/site-packages/flattentool/input.py", line 23, in <module>
    from flattentool.ODSReader import ODSReader
  File "/opt/hostedtoolcache/PyPy/3.7.13/x64/site-packages/flattentool/ODSReader.py", line 21, in <module>
    import backports.datetime_fromisoformat
  File "/opt/hostedtoolcache/PyPy/3.7.13/x64/site-packages/backports/datetime_fromisoformat/__init__.py", line 4, in <module>
    from backports._datetime_fromisoformat import date_fromisoformat, datetime_fromisoformat, time_fromisoformat, FixedOffset
ImportError: /opt/hostedtoolcache/PyPy/3.7.13/x64/site-packages/backports/_datetime_fromisoformat.pypy37-pp73-x86_64-linux-gnu.so: undefined symbol: _PyUnicode_Copy
```

Note to self to restore testing on pypy-3.7 in lib-cove-oc4ids once this is merged.