### PR TITLE
docs: Change back to dirhtml as builder

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+  builder: dirhtml
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html


### PR DESCRIPTION
This was previously configured in the readthedocs admin, but wasn't carried over to the new `.readthedocs.yaml`.

Example of a fixed url: https://flatten-tool.readthedocs.io/en/fix-readthedocs-yaml/introduction/ instead of https://flatten-tool.readthedocs.io/en/latest/introduction.html