### PR TITLE
Remove restriction on CSV filename length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Flatten & Create Template: Previously, CSV filenames were truncated to 31 characters, which is the maximum length of a sheet name in Excel.
+  Now allow CSV filenames of any length and only truncate sheet names when the output format is XLSX or ODS.
+  https://github.com/OpenDataServices/flatten-tool/pull/428
+
+### Fixed
+
+- flatten --sheet-prefix option does not work in ODS files https://github.com/OpenDataServices/flatten-tool/issues/430
+
 ## [0.22.0] - 2023-06-27
 
 ### Added

--- a/flattentool/output.py
+++ b/flattentool/output.py
@@ -62,7 +62,7 @@ class XLSXOutput(SpreadsheetOutput):
     def write_sheet(self, sheet_name, sheet):
         sheet_header = list(sheet)
         worksheet = self.workbook.create_sheet()
-        worksheet.title = self.sheet_prefix + sheet_name
+        worksheet.title = (self.sheet_prefix + sheet_name)[:31]
         worksheet.append(sheet_header)
         for sheet_line in sheet.lines:
             line = []
@@ -131,7 +131,7 @@ class ODSOutput(SpreadsheetOutput):
 
     def write_sheet(self, sheet_name, sheet):
 
-        worksheet = odf.table.Table(name=sheet_name)
+        worksheet = odf.table.Table(name=(self.sheet_prefix + sheet_name)[:31])
         sheet_header = list(sheet)
 
         header_row = odf.table.TableRow()

--- a/flattentool/schema.py
+++ b/flattentool/schema.py
@@ -37,7 +37,7 @@ def make_sub_sheet_name(
             x[:truncation_length] for x in parent_path.split(path_separator) if x != "0"
         )
         + property_name
-    )[:31]
+    )
 
 
 class TitleLookup(UserDict):


### PR DESCRIPTION
Previously, CSV filenames were truncated to 31 characters, which is the maximum length of a sheet name in Excel. This PR allows CSV filenames of any length and only truncates sheet names when the output format is XLSX or ODS.