### PR TITLE
fix: Ignore null characters in the input CSV file when getting non-header rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore null characters in the input CSV file when getting non-header rows
+
 ## [0.25.0] - 2024-07-05
 
 ### Fixed
@@ -31,7 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Ignore null characters in the input CSV file
+- Ignore null characters in the input CSV file when getting header rows
   https://github.com/OpenDataServices/flatten-tool/pull/435
 
 ## [0.24.0] - 2023-11-15

--- a/flattentool/input.py
+++ b/flattentool/input.py
@@ -688,7 +688,7 @@ class CSVInput(SpreadsheetInput):
         with open(
             os.path.join(self.input_name, sheet_name + ".csv"), encoding=self.encoding
         ) as main_sheet_file:
-            dictreader = DictReader(main_sheet_file)
+            dictreader = DictReader(NullCharacterFilter(main_sheet_file))
             for row in self.generate_rows(dictreader, sheet_name):
                 yield row
 


### PR DESCRIPTION
Okay, this is the last place where `open` is called on a CSV (previous fixes were #446 and #435/#436)