### PR TITLE
fix: Read bytes to avoid ijson deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid deprecation warning from the ijson package.
+
 ## [0.26.0] - 2024-08-22
 
 ### Fixed

--- a/flattentool/json_input.py
+++ b/flattentool/json_input.py
@@ -47,6 +47,10 @@ class BadlyFormedJSONError(FlattenToolError, ValueError):
 
 
 class BadlyFormedJSONErrorUTF8(BadlyFormedJSONError):
+    """
+    Deprecated. This exception is no longer raised.
+    """
+
     pass
 
 
@@ -310,8 +314,6 @@ class JSONParser(object):
             self.parse()
         except ijson.common.IncompleteJSONError as err:
             raise BadlyFormedJSONError(*err.args)
-        except UnicodeDecodeError as err:
-            raise BadlyFormedJSONErrorUTF8(*err.args)
         finally:
             if json_filename:
                 json_file.close()

--- a/flattentool/json_input.py
+++ b/flattentool/json_input.py
@@ -302,7 +302,7 @@ class JSONParser(object):
             else:
                 path = root_list_path.replace("/", ".") + ".item"
 
-            json_file = codecs.open(json_filename, encoding="utf-8")
+            json_file = codecs.open(json_filename, "rb")
 
             self.root_json_list = ijson.items(json_file, path, map_type=OrderedDict)
 

--- a/flattentool/tests/test_json_input.py
+++ b/flattentool/tests/test_json_input.py
@@ -8,11 +8,7 @@ from decimal import Decimal
 
 import pytest
 
-from flattentool.json_input import (
-    BadlyFormedJSONError,
-    BadlyFormedJSONErrorUTF8,
-    JSONParser,
-)
+from flattentool.json_input import BadlyFormedJSONError, JSONParser
 from flattentool.schema import SchemaParser
 from flattentool.tests.test_schema_parser import object_in_array_example_properties
 
@@ -35,9 +31,6 @@ def test_jsonparser_bad_json_utf8():
     name = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "fixtures", "bad-utf8.json"
     )
-    # matches against the special error type
-    with pytest.raises(BadlyFormedJSONErrorUTF8):
-        JSONParser(json_filename=name)
     # matches against our base error type
     with pytest.raises(BadlyFormedJSONError):
         JSONParser(json_filename=name)


### PR DESCRIPTION
Otherwise:

```
DeprecationWarning: 
ijson works by reading bytes, but a string reader has been given instead. This
probably, but not necessarily, means a file-like object has been opened in text
mode ('t') rather than binary mode ('b').

An automatic conversion is being performed on the fly to continue, but on the
other hand this creates unnecessary encoding/decoding operations that decrease
the efficiency of the system. In the future this automatic conversion will be
removed, and users will receive errors instead of this warning. To avoid this
problem make sure file-like objects are opened in binary mode instead of text
mode.
```

encoding="utf-8" needs to be removed, as codes.open will use mode "rt" instead of "rb" if it's present, and ijson will read the bytes as UTF-8 anyway.

Note that ijson has no special exception class for UTF-8 errors, so one test had to change.